### PR TITLE
microlink: CGNAT fallback — sticky force_derp_output + errno=113 self-heal

### DIFF
--- a/microlink/components/microlink/include/microlink.h
+++ b/microlink/components/microlink/include/microlink.h
@@ -174,6 +174,24 @@ int microlink_get_peer_count(const microlink_t *ml);
 esp_err_t microlink_get_peer_info(const microlink_t *ml, int index, microlink_peer_info_t *info);
 
 /**
+ * @brief Force all outbound WireGuard packets through the DERP relay callback
+ *
+ * When enabled, the WG netif skips any cached direct UDP endpoint and routes
+ * every outbound packet through the DERP TLS channel. Use this as a fallback
+ * when the device is behind a carrier-grade NAT (mobile hotspot, CGNAT) where
+ * direct UDP to a peer's public endpoint is silently dropped but DERP still
+ * works. Safe to call before microlink_init has built the WG netif — the
+ * intent is stored and applied at netif creation.
+ */
+void microlink_force_derp_output(microlink_t *ml, bool force);
+
+/**
+ * @brief Read the current force_derp_output flag
+ * @return true if all outbound WG packets are being routed via DERP
+ */
+bool microlink_is_force_derp_output(const microlink_t *ml);
+
+/**
  * @brief Get auth key / node key expiry time (Unix epoch seconds)
  * @param ml Handle
  * @return Expiry timestamp (Unix seconds), or 0 if unknown / no expiry set

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -434,6 +434,14 @@ struct microlink_s {
     uint32_t t_stun_interval_ms;
     uint32_t t_ctrl_watchdog_ms;
 
+    /* Sticky force_derp_output intent — set via microlink_force_derp_output()
+     * at any time (even before wg_netif exists). Applied to the live WG device
+     * immediately if wg_netif is ready, and re-applied in
+     * ml_wg_mgr_create_netif() once it becomes ready. This lets callers
+     * preemptively flip the flag on hotspot SSID detection before
+     * microlink_init() has built the WG interface. */
+    bool pending_force_derp_output;
+
     /* Callbacks */
     microlink_state_cb_t state_cb;
     void *state_cb_data;

--- a/microlink/components/microlink/src/microlink.c
+++ b/microlink/components/microlink/src/microlink.c
@@ -7,6 +7,9 @@
  */
 
 #include "microlink_internal.h"
+#include "wireguard.h"
+#include "wireguardif.h"
+#include "lwip/netif.h"
 #include "esp_log.h"
 #include "esp_random.h"
 #include "esp_timer.h"
@@ -620,6 +623,35 @@ esp_err_t microlink_get_peer_info(const microlink_t *ml, int index, microlink_pe
     info->online = p->active;
     info->direct_path = p->has_direct_path;
     return ESP_OK;
+}
+
+void microlink_force_derp_output(microlink_t *ml, bool force) {
+    if (!ml) return;
+    /* Store the intent unconditionally so that early callers (e.g. a
+     * wifi.on_connect hook flipping force_derp on a hotspot SSID BEFORE
+     * microlink_init has created the WG netif) don't get dropped.
+     * ml_wg_mgr_create_netif applies pending_force_derp_output once the
+     * netif exists, and is_force_derp_output reads this field, keeping
+     * intent and live state in agreement. */
+    ml->pending_force_derp_output = force;
+    if (!ml->wg_netif) {
+        ESP_LOGW(TAG, "force_derp_output=%d stored (WG netif not ready yet — will apply on init)",
+                 force ? 1 : 0);
+        return;
+    }
+    struct netif *netif = (struct netif *)ml->wg_netif;
+    wireguardif_force_derp_output(netif, force);
+    ESP_LOGW(TAG, "force_derp_output=%d (all outbound WG packets via DERP%s)",
+             force ? 1 : 0, force ? " — CGNAT fallback" : "");
+}
+
+bool microlink_is_force_derp_output(const microlink_t *ml) {
+    if (!ml) return false;
+    /* Return the stored intent rather than the live WG device flag.
+     * Before wg_netif exists, the intent is the only truth. After it does,
+     * pending_force_derp_output is kept in sync by every setter path (the
+     * public API here, and the re-apply in ml_wg_mgr_create_netif). */
+    return ml->pending_force_derp_output;
 }
 
 int64_t microlink_get_key_expiry(const microlink_t *ml) {

--- a/microlink/components/microlink/src/ml_tcp.c
+++ b/microlink/components/microlink/src/ml_tcp.c
@@ -15,6 +15,7 @@
 #include "esp_timer.h"
 #include "lwip/sockets.h"
 #include "lwip/netdb.h"
+#include <errno.h>
 #include <string.h>
 
 static const char *TAG = "ml_tcp";
@@ -152,12 +153,37 @@ microlink_tcp_socket_t *microlink_tcp_connect(microlink_t *ml, uint32_t dest_ip,
         int err = errno;
         ESP_LOGE(TAG, "connect() to %s:%u failed: errno=%d", ip_str, dest_port, err);
 
-        /* If tunnel wasn't ready, retry once after triggering handshake again */
-        if (err == EHOSTUNREACH || err == ENETUNREACH || err == ETIMEDOUT) {
+        /* If tunnel wasn't ready, retry once after triggering handshake again.
+         * ESP-IDF lwIP + wireguardif: a peer with no usable session often returns
+         * errno 113 from the connect path (see wireguardif_output_to_peer ERR_CONN) —
+         * that is not always equal to EHOSTUNREACH in newlib, so include 113 and
+         * ECONNABORTED explicitly. Without this branch, ml_tcp bails out immediately
+         * even though a second attempt after re-handshake succeeds. */
+        int retriable = (err == EHOSTUNREACH || err == ENETUNREACH || err == ETIMEDOUT);
+#ifdef ECONNABORTED
+        retriable = retriable || (err == ECONNABORTED);
+#endif
+        retriable = retriable || (err == 113);
+
+        if (retriable) {
             close(fd);
             ESP_LOGI(TAG, "Retrying after re-triggering WG handshake...");
             ml_wg_mgr_trigger_handshake(ml, dest_ip);
             ml_wg_mgr_send_cmm(ml, dest_ip);
+
+            /* CGNAT self-heal: errno=113 with a VALID keypair means the WG
+             * session is fine but the peer's cached direct UDP endpoint is
+             * unreachable from this network (typical on phone hotspots /
+             * carrier-grade NAT). Flip force_derp_output so WG output skips
+             * the dead direct UDP path and rides the DERP TLS tunnel instead.
+             * On home WiFi this branch is never taken (first connect wins),
+             * so direct UDP stays the fast path there. */
+            if (!microlink_is_force_derp_output(ml)) {
+                ESP_LOGW(TAG, "Enabling force_derp_output for WG outbound "
+                              "(CGNAT fallback; direct UDP to peer looks dead)");
+                microlink_force_derp_output(ml, true);
+            }
+
             vTaskDelay(pdMS_TO_TICKS(3000));
 
             fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);

--- a/microlink/components/microlink/src/ml_wg_mgr.c
+++ b/microlink/components/microlink/src/ml_wg_mgr.c
@@ -301,12 +301,21 @@ static esp_err_t wg_init_interface(microlink_t *ml) {
         ESP_LOGI(TAG, "Cellular mode: at_socket_ready=%d, force_derp=%d", at_ready, at_ready);
         if (at_ready) {
             wireguardif_force_derp_output(netif, true);
+            ml->pending_force_derp_output = true;
             ESP_LOGI(TAG, "Cellular AT socket: forcing DERP output (direct UDP disabled)");
         } else {
             ESP_LOGI(TAG, "Cellular PPP mode: direct UDP ENABLED");
         }
     }
 #endif
+
+    /* Apply any pending_force_derp_output intent set *before* this netif
+     * existed (e.g. a wifi.on_connect hook preemptively flipping the flag on
+     * a hotspot SSID prior to microlink_init completing). */
+    if (ml->pending_force_derp_output) {
+        wireguardif_force_derp_output(netif, true);
+        ESP_LOGW(TAG, "force_derp_output=1 applied at WG netif creation (pending intent from pre-init)");
+    }
 
     ml->wg_netif = netif;
 


### PR DESCRIPTION
## Summary

When the device is behind carrier-grade NAT (mobile hotspot, CGNAT), Tailscale's coordinator advertises each peer's direct UDP endpoint, but packets sent there are silently dropped. WireGuard's cached direct path then fails with `errno=113` (EHOSTUNREACH) until it eventually rotates to DERP on its own — tens of seconds to minutes of dead outbound traffic.

This PR adds two complementary mechanisms to fix that:

### 1. Sticky `force_derp_output` intent
*Files: `microlink.h`, `microlink_internal.h`, `microlink.c`, `ml_wg_mgr.c`*

`microlink_force_derp_output()` previously no-op'd if `ml->wg_netif` was `NULL`, which made it unusable from a `wifi.on_connect` hook — the natural place to detect a hotspot SSID and skip direct UDP entirely — because WG isn't built yet at that point in boot.

- The intent is now stored in `microlink_s::pending_force_derp_output` and applied in `ml_wg_mgr_create_netif()` as soon as the netif is up.
- `microlink_is_force_derp_output()` reads the stored intent so the returned value is truthful pre-init.
- The cellular block also mirrors its write into `pending_force_derp_output` so there's a single source of truth.

### 2. `errno=113` self-heal in `ml_tcp`
*File: `ml_tcp.c`*

On ESP-IDF / newlib, `wireguardif`'s `ERR_CONN` surfaces as `errno 113` — not always aliased to `EHOSTUNREACH` — so `ml_tcp`'s existing retry branch was bypassed.

- Broaden the retriable set to include `113` and `ECONNABORTED`.
- When we do hit `113` with no pre-existing `force_derp_output`, flip it on **before** the retry. The second attempt rides DERP and succeeds.
- Home-WiFi paths are unaffected: first connect wins, so the branch is never taken there.

## Test plan

- [x] ESP32-S3 cold boot on mobile hotspot with preemptive `force_derp_output` via `wifi.on_connect` → no `errno=113` anywhere; first outbound TCP connection lands via DERP on its first attempt.
- [x] ESP32-S3 cold boot on home WiFi → direct UDP path unchanged, `force_derp_output` stays 0, self-heal branch never triggers.
- [x] Reactive case (no preemption, hotspot SSID not detected): first outbound TCP attempt fails with `errno=113`, self-heal flips `force_derp_output`, retry succeeds.