### PR TITLE
fix: reassemble HTTP/2 frames split across reads

### DIFF
--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -584,6 +584,11 @@ struct microlink_s {
      * and then exactly that many bytes. A message can span several H2 DATA frames and several Noise
      * frames, so the reader must accumulate — do_map_exchange already does, for the reason its own
      * comment gives ("a single H2 frame can span multiple Noise frames"); the long-poll path did not. */
+    /* HTTP/2 frame reassembly for the long-poll socket. A DATA frame whose
+     * payload is split across two reads must be completed, not dropped. */
+    uint8_t *h2_acc;
+    size_t   h2_acc_len;
+
     uint8_t *lp_acc;         /* PSRAM, ML_JSON_BUFFER_SIZE, lazily allocated */
     size_t   lp_acc_len;
 

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -366,6 +366,10 @@ typedef struct {
  * DERP Map Types (parsed from MapResponse, used by coord + STUN)
  * ========================================================================== */
 
+/* Largest HTTP/2 frame we will attempt to reassemble. The wire field is 24-bit
+ * (16 MB); anything beyond what fits in one read buffer can never complete. */
+#define ML_H2_MAX_FRAME_LEN     32768
+
 #define ML_MAX_DERP_REGIONS     32
 #define ML_MAX_DERP_NODES       4
 

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -579,6 +579,14 @@ struct microlink_s {
      * The COORD_LONG_POLL stream watchdog reconnects off this clock. */
     volatile uint64_t ctrl_stream_rx_ms;
 
+    /* Long-poll MapResponse reassembly buffer. The streamed map session is length-prefixed; see
+     * tailscale/control/controlclient/direct.go:1304-1311, which reads a 4-byte LITTLE-ENDIAN size
+     * and then exactly that many bytes. A message can span several H2 DATA frames and several Noise
+     * frames, so the reader must accumulate — do_map_exchange already does, for the reason its own
+     * comment gives ("a single H2 frame can span multiple Noise frames"); the long-poll path did not. */
+    uint8_t *lp_acc;         /* PSRAM, ML_JSON_BUFFER_SIZE, lazily allocated */
+    size_t   lp_acc_len;
+
     /* Key expiry (parsed from MapResponse self-node) */
     int64_t key_expiry_epoch;       /* Unix epoch seconds, 0 = no expiry */
     bool key_expired;               /* true if Node.Expired == true */

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -2869,6 +2869,43 @@ static int do_send_endpoint_update(microlink_t *ml, ml_noise_state_t *noise) {
 }
 
 /* Try to read one incremental MapResponse update (non-blocking) */
+/* Apply one fully-decoded MapResponse from the long-poll stream.
+ * Extracted from poll_map_update so the caller can drive it once per COMPLETE message rather than
+ * once per socket read. See the reassembly note on microlink_t::lp_acc. */
+static void apply_long_poll_map(microlink_t *ml, cJSON *update_json) {
+    ESP_LOGI(TAG, "Long-poll MapResponse update received");
+
+    /* Update VPN IP if present */
+    cJSON *node = cJSON_GetObjectItem(update_json, "Node");
+    if (node) {
+        cJSON *addresses = cJSON_GetObjectItem(node, "Addresses");
+        if (addresses && cJSON_GetArraySize(addresses) > 0) {
+            const char *addr = cJSON_GetArrayItem(addresses, 0)->valuestring;
+            if (addr) {
+                unsigned a, b, c, d;
+                if (sscanf(addr, "%u.%u.%u.%u", &a, &b, &c, &d) == 4) {
+                    uint32_t new_ip = (a << 24) | (b << 16) | (c << 8) | d;
+                    if (new_ip != ml->vpn_ip) {
+                        ml->vpn_ip = new_ip;
+                        ESP_LOGI(TAG, "VPN IP updated via long-poll");
+                    }
+                }
+            }
+        }
+    }
+
+    /* Parse peer updates */
+    parse_peers_from_map_response(ml, update_json);
+
+    /* The DERPMap can arrive on the stream too - Headscale >= 0.26 delivers the ENTIRE initial
+     * netmap here (the non-streaming fetch returns an empty body, see do_map_exchange). Parse it
+     * and kick the DERP I/O task if it has not connected yet. */
+    if (parse_derp_map_from_response(ml, update_json) && !ml->derp.connected) {
+        ESP_LOGI(TAG, "DERPMap arrived via long-poll - signaling DERP connect");
+        xEventGroupSetBits(ml->events, ML_EVT_DERP_CONNECT_REQ);
+    }
+}
+
 static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
     /* Use select() to check if data is available before blocking in recv */
     fd_set readfds;
@@ -2983,61 +3020,73 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
         noise_send(ml, noise, wu_buf, wu_len);
     }
 
-    if (!json_data || json_data_len == 0) {
-        /* Keepalive, SETTINGS, or PING frame - not an error */
-        free(frame_buf);
-        return 1;  /* Got data, reset watchdog */
-    }
-
-    /* Skip 4-byte length prefix if present */
-    char *parse_start = (char *)json_data;
-    size_t parse_len = json_data_len;
-    if (parse_len > 4 && parse_start[4] == '{') {
-        parse_start += 4;
-        parse_len -= 4;
-    }
-
-    char saved = parse_start[parse_len];
-    parse_start[parse_len] = '\0';
-
-    cJSON *update_json = cJSON_Parse(parse_start);
-    parse_start[parse_len] = saved;
-
-    if (update_json) {
-        ESP_LOGI(TAG, "Long-poll MapResponse update received");
-
-        /* Update VPN IP if present */
-        cJSON *node = cJSON_GetObjectItem(update_json, "Node");
-        if (node) {
-            cJSON *addresses = cJSON_GetObjectItem(node, "Addresses");
-            if (addresses && cJSON_GetArraySize(addresses) > 0) {
-                const char *addr = cJSON_GetArrayItem(addresses, 0)->valuestring;
-                if (addr) {
-                    unsigned a, b, c, d;
-                    if (sscanf(addr, "%u.%u.%u.%u", &a, &b, &c, &d) == 4) {
-                        uint32_t new_ip = (a << 24) | (b << 16) | (c << 8) | d;
-                        if (new_ip != ml->vpn_ip) {
-                            ml->vpn_ip = new_ip;
-                            ESP_LOGI(TAG, "VPN IP updated via long-poll");
-                        }
-                    }
-                }
+    /* ---- Reassemble and drain complete messages ---------------------------------------------
+     * Framing per tailscale/control/controlclient/direct.go:1304-1311:
+     *     var siz [4]byte; io.ReadFull(body, siz[:])
+     *     size := binary.LittleEndian.Uint32(siz[:])
+     *     msg := make([]byte, size); io.ReadFull(body, msg)
+     * i.e. a 4-byte LITTLE-ENDIAN length followed by exactly that many bytes. The reference is a
+     * framed reader by construction and cannot half-read a message; this makes ours one too.
+     *
+     * Previously this function pointed at whichever stream-5 DATA frame happened to be last in one
+     * read, so any MapResponse spanning more than one frame failed cJSON_Parse and was dropped
+     * SILENTLY - with ctrl_stream_rx_ms already stamped above, so every liveness signal stayed green
+     * while netmap updates were lost. Compression is disabled (Compress: ""), so responses arrive at
+     * full size and spanning is the normal case for anything but a keepalive. */
+    if (json_data && json_data_len > 0) {
+        if (!ml->lp_acc) {
+            ml->lp_acc = ml_psram_malloc(ML_JSON_BUFFER_SIZE);
+            ml->lp_acc_len = 0;
+        }
+        if (ml->lp_acc) {
+            if (ml->lp_acc_len + json_data_len > ML_JSON_BUFFER_SIZE) {
+                ESP_LOGW(TAG, "long-poll accumulator would overflow (%u + %u) - resetting",
+                         (unsigned)ml->lp_acc_len, (unsigned)json_data_len);
+                ml->lp_acc_len = 0;
+            }
+            if (ml->lp_acc_len + json_data_len <= ML_JSON_BUFFER_SIZE) {
+                memcpy(ml->lp_acc + ml->lp_acc_len, json_data, json_data_len);
+                ml->lp_acc_len += json_data_len;
             }
         }
+    }
 
-        /* Parse peer updates */
-        parse_peers_from_map_response(ml, update_json);
+    if (ml->lp_acc && ml->lp_acc_len >= 4) {
+        size_t consumed = 0;
+        for (;;) {
+            size_t avail = ml->lp_acc_len - consumed;
+            if (avail < 4) break;
+            uint8_t *m = ml->lp_acc + consumed;
+            uint32_t size = (uint32_t)m[0] | ((uint32_t)m[1] << 8) |
+                            ((uint32_t)m[2] << 16) | ((uint32_t)m[3] << 24);
+            /* A size we could never satisfy means we are out of frame. Losing one update is
+             * recoverable; a permanently stuck accumulator is not. */
+            if (size == 0 || size > ML_JSON_BUFFER_SIZE) {
+                ESP_LOGW(TAG, "long-poll: implausible message size %lu - discarding %u buffered bytes",
+                         (unsigned long)size, (unsigned)ml->lp_acc_len);
+                ml->lp_acc_len = 0;
+                consumed = 0;
+                break;
+            }
+            if (avail < 4 + (size_t)size) break;   /* incomplete - keep for the next read */
 
-        /* The DERPMap can arrive on the stream too — Headscale >= 0.26
-         * delivers the ENTIRE initial netmap here (the non-streaming fetch
-         * returns an empty body, see do_map_exchange).  Parse it and kick
-         * the DERP I/O task if it has not connected yet. */
-        if (parse_derp_map_from_response(ml, update_json) && !ml->derp.connected) {
-            ESP_LOGI(TAG, "DERPMap arrived via long-poll — signaling DERP connect");
-            xEventGroupSetBits(ml->events, ML_EVT_DERP_CONNECT_REQ);
+            char *ps = (char *)m + 4;
+            char saved = ps[size];
+            ps[size] = '\0';
+            cJSON *update_json = cJSON_Parse(ps);
+            ps[size] = saved;
+            if (update_json) {
+                apply_long_poll_map(ml, update_json);
+                cJSON_Delete(update_json);
+            } else {
+                ESP_LOGW(TAG, "long-poll: %lu-byte message failed to parse", (unsigned long)size);
+            }
+            consumed += 4 + size;
         }
-
-        cJSON_Delete(update_json);
+        if (consumed > 0 && consumed <= ml->lp_acc_len) {
+            memmove(ml->lp_acc, ml->lp_acc + consumed, ml->lp_acc_len - consumed);
+            ml->lp_acc_len -= consumed;
+        }
     }
 
     free(frame_buf);

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -2359,22 +2359,20 @@ static int do_map_exchange(microlink_t *ml, ml_noise_state_t *noise, bool send_r
         /* Streaming responses (send_request=false) never carry END_STREAM —
          * the message boundary is the 4-byte length prefix in front of the
          * JSON body. Stop reading once the prefixed message is complete.
-         * The prefix endianness is not spelled out anywhere authoritative
-         * for this stack, so accept whichever plausible reading is larger;
-         * an implausible prefix simply falls back to the recv timeout. */
+         *
+         * The prefix is little-endian; this used to try both endiannesses and
+         * take whichever looked larger, which could overestimate how long to
+         * wait. See control/controlclient/direct.go:1303-1311, which this
+         * series now follows everywhere else - reading it two ways here while
+         * asserting one reading elsewhere was inconsistent. */
         if (!send_request && !got_end_stream &&
             first_data_payload && first_data_len >= 4) {
             uint32_t le = (uint32_t)first_data_payload[0] |
                           ((uint32_t)first_data_payload[1] << 8) |
                           ((uint32_t)first_data_payload[2] << 16) |
                           ((uint32_t)first_data_payload[3] << 24);
-            uint32_t be = ((uint32_t)first_data_payload[0] << 24) |
-                          ((uint32_t)first_data_payload[1] << 16) |
-                          ((uint32_t)first_data_payload[2] << 8) |
-                           (uint32_t)first_data_payload[3];
             uint32_t need = 0;
             if (le >= 2 && le < ML_JSON_BUFFER_SIZE) need = le;
-            if (be >= 2 && be < ML_JSON_BUFFER_SIZE && be > need) need = be;
             if (need > 0 && scan_data_total >= (size_t)need + 4) {
                 ESP_LOGI(TAG, "Streamed MapResponse complete (%lu+4 bytes) after %d Noise frames",
                          (unsigned long)need, read_count + 1);

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -535,6 +535,14 @@ static void ml_conn_close(microlink_t *ml) {
         ml_close_sock(ml->coord_sock);
         ml->coord_sock = -1;
     }
+
+    /* Drop any partially-received HTTP/2 frame and any partially-assembled
+     * map message. These belong to the session that just ended; carrying them
+     * into the next one prepends stale bytes to its FIRST framed message -
+     * which is the initial full netmap, the most valuable message on the
+     * stream. It would be lost to the length-prefix guard. */
+    ml->h2_acc_len = 0;
+    ml->lp_acc_len = 0;
 }
 
 /* ============================================================================
@@ -2934,7 +2942,11 @@ static void apply_long_poll_map(microlink_t *ml, cJSON *update_json) {
 static void lp_acc_append(microlink_t *ml, const uint8_t *data, size_t len) {
     if (!data || len == 0) return;
     if (!ml->lp_acc) {
-        ml->lp_acc = ml_psram_malloc(ML_JSON_BUFFER_SIZE);
+        /* +1: the drain loop NUL-terminates in place at ps[size], which is one
+         * past the last message byte. A message ending exactly at the buffer
+         * end would otherwise write one byte past the allocation, and `size`
+         * comes off the wire. */
+        ml->lp_acc = ml_psram_malloc(ML_JSON_BUFFER_SIZE + 1);
         ml->lp_acc_len = 0;
         if (!ml->lp_acc) return;
     }
@@ -3027,6 +3039,18 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
                              (frame_buf[pos + 7] << 8) | frame_buf[pos + 8];
         pos += 9;
 
+        /* A 24-bit length field can claim up to 16 MB, which can never be
+         * satisfied from a 64 KB read buffer: we would carry forever, shrink
+         * the read window to zero and stall until the watchdog fires. Treat an
+         * unsatisfiable frame as a protocol error. */
+        if (f_len > ML_H2_MAX_FRAME_LEN) {
+            ESP_LOGE(TAG, "H2 frame length %lu exceeds %d - protocol error, dropping session state",
+                     (unsigned long)f_len, ML_H2_MAX_FRAME_LEN);
+            ml->h2_acc_len = 0;
+            ml->lp_acc_len = 0;
+            break;
+        }
+
         if (pos + (int)f_len > frame_len) {
             /* Partial frame: stash the header AND the bytes we do have, so the
              * next read completes it. Dropping it here is what desynchronised
@@ -3076,6 +3100,18 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
             noise_send(ml, noise, settings_ack, sizeof(settings_ack));
         }
         pos += f_len;
+    }
+
+    /* A read can also end mid-HEADER (1-8 bytes of the 9-byte prefix). The loop
+     * above stops on `pos + 9 <= frame_len`, so those bytes would be dropped and
+     * desynchronise the stream exactly as a split payload does. Carry them too. */
+    if (pos < frame_len && ml->h2_acc_len == 0) {
+        size_t left = (size_t)frame_len - (size_t)pos;
+        if (!ml->h2_acc) ml->h2_acc = ml_psram_malloc(65536);
+        if (ml->h2_acc && left <= 65536) {
+            memcpy(ml->h2_acc, frame_buf + pos, left);
+            ml->h2_acc_len = left;
+        }
     }
 
     /* Send HTTP/2 WINDOW_UPDATE to replenish flow control after receiving DATA.

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -2986,7 +2986,25 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
     uint8_t *frame_buf = ml_psram_malloc(65536);
     if (!frame_buf) return 0;
 
-    int frame_len = noise_recv(ml, noise, frame_buf, 65536);
+    /* Prepend bytes left over from the previous read. An H2 DATA frame whose
+     * payload straddles a read boundary used to be dropped outright by the
+     * `pos + f_len > frame_len` break below, so its head was lost and every
+     * byte after it was mis-parsed as the start of a new message. */
+    size_t carry = 0;
+    if (ml->h2_acc && ml->h2_acc_len > 0) {
+        carry = ml->h2_acc_len;
+        if (carry > 65536) carry = 0;          /* cannot happen; be safe */
+        if (carry) memcpy(frame_buf, ml->h2_acc, carry);
+        ml->h2_acc_len = 0;
+    }
+
+    int rcvd = noise_recv(ml, noise, frame_buf + carry, 65536 - carry);
+    int frame_len = (rcvd > 0) ? rcvd + (int)carry : rcvd;
+
+    if (rcvd <= 0 && carry > 0) {
+        /* Nothing new this time - keep what we had for the next read. */
+        if (ml->h2_acc) { memcpy(ml->h2_acc, frame_buf, carry); ml->h2_acc_len = carry; }
+    }
 
     if (frame_len <= 0) {
         free(frame_buf);
@@ -3009,7 +3027,23 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
                              (frame_buf[pos + 7] << 8) | frame_buf[pos + 8];
         pos += 9;
 
-        if (pos + (int)f_len > frame_len) break;
+        if (pos + (int)f_len > frame_len) {
+            /* Partial frame: stash the header AND the bytes we do have, so the
+             * next read completes it. Dropping it here is what desynchronised
+             * the message reader - see the h2_acc comment above. */
+            size_t start = (size_t)pos - 9;          /* include the 9-byte header */
+            size_t left  = (size_t)frame_len - start;
+            if (!ml->h2_acc) ml->h2_acc = ml_psram_malloc(65536);
+            if (ml->h2_acc && left <= 65536) {
+                memcpy(ml->h2_acc, frame_buf + start, left);
+                ml->h2_acc_len = left;
+            } else {
+                ESP_LOGW(TAG, "H2: cannot carry %u-byte partial frame - dropping",
+                         (unsigned)left);
+                if (ml->h2_acc) ml->h2_acc_len = 0;
+            }
+            break;
+        }
 
         if (f_type == 0x00) {  /* DATA frame */
             total_data_bytes += f_len;

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -21,6 +21,7 @@
  *            tailscale/control/controlclient/direct.go
  */
 
+#include <ctype.h>
 #include "microlink_internal.h"
 #include "ml_x25519.h"
 #include "esp_log.h"
@@ -2906,6 +2907,30 @@ static void apply_long_poll_map(microlink_t *ml, cJSON *update_json) {
     }
 }
 
+/* Append one stream-5 DATA payload to the long-poll reassembly buffer.
+ * MUST be called for EVERY stream-5 DATA frame in a read, not just the last one:
+ * a single read can carry several, and keeping only the last leaves the
+ * accumulator starting mid-message, which then mis-reads JSON bytes as a length
+ * prefix. (Observed on hardware: "implausible message size 808333626" - that is
+ * the ASCII ":1.0" read as a little-endian uint32.) */
+static void lp_acc_append(microlink_t *ml, const uint8_t *data, size_t len) {
+    if (!data || len == 0) return;
+    if (!ml->lp_acc) {
+        ml->lp_acc = ml_psram_malloc(ML_JSON_BUFFER_SIZE);
+        ml->lp_acc_len = 0;
+        if (!ml->lp_acc) return;
+    }
+    if (ml->lp_acc_len + len > ML_JSON_BUFFER_SIZE) {
+        ESP_LOGW(TAG, "long-poll accumulator would overflow (%u + %u) - resetting",
+                 (unsigned)ml->lp_acc_len, (unsigned)len);
+        ml->lp_acc_len = 0;
+    }
+    if (ml->lp_acc_len + len <= ML_JSON_BUFFER_SIZE) {
+        memcpy(ml->lp_acc + ml->lp_acc_len, data, len);
+        ml->lp_acc_len += len;
+    }
+}
+
 static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
     /* Use select() to check if data is available before blocking in recv */
     fd_set readfds;
@@ -2954,8 +2979,6 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
     }
 
     /* Extract DATA frame payload from H2 frames, track flow control */
-    uint8_t *json_data = NULL;
-    size_t json_data_len = 0;
     uint32_t total_data_bytes = 0;
     uint32_t data_stream_id = 0;
     int pos = 0;
@@ -2979,10 +3002,8 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
                  * stream-liveness clock the COORD_LONG_POLL watchdog reads. */
                 ml->ctrl_stream_rx_ms = ml_get_time_ms();
                 data_stream_id = f_stream;
-                if (f_len > 0) {
-                    json_data = frame_buf + pos;
-                    json_data_len = f_len;
-                }
+                /* Append EVERY stream-5 DATA frame - see lp_acc_append(). */
+                lp_acc_append(ml, frame_buf + pos, f_len);
             } else if (f_len > 0) {
                 /* Endpoint update response (stream 7+) — discard body */
                 ESP_LOGD(TAG, "H2 stream %lu DATA: %lu bytes (discarded)",
@@ -3033,24 +3054,6 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
      * SILENTLY - with ctrl_stream_rx_ms already stamped above, so every liveness signal stayed green
      * while netmap updates were lost. Compression is disabled (Compress: ""), so responses arrive at
      * full size and spanning is the normal case for anything but a keepalive. */
-    if (json_data && json_data_len > 0) {
-        if (!ml->lp_acc) {
-            ml->lp_acc = ml_psram_malloc(ML_JSON_BUFFER_SIZE);
-            ml->lp_acc_len = 0;
-        }
-        if (ml->lp_acc) {
-            if (ml->lp_acc_len + json_data_len > ML_JSON_BUFFER_SIZE) {
-                ESP_LOGW(TAG, "long-poll accumulator would overflow (%u + %u) - resetting",
-                         (unsigned)ml->lp_acc_len, (unsigned)json_data_len);
-                ml->lp_acc_len = 0;
-            }
-            if (ml->lp_acc_len + json_data_len <= ML_JSON_BUFFER_SIZE) {
-                memcpy(ml->lp_acc + ml->lp_acc_len, json_data, json_data_len);
-                ml->lp_acc_len += json_data_len;
-            }
-        }
-    }
-
     if (ml->lp_acc && ml->lp_acc_len >= 4) {
         size_t consumed = 0;
         for (;;) {
@@ -3062,8 +3065,12 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
             /* A size we could never satisfy means we are out of frame. Losing one update is
              * recoverable; a permanently stuck accumulator is not. */
             if (size == 0 || size > ML_JSON_BUFFER_SIZE) {
-                ESP_LOGW(TAG, "long-poll: implausible message size %lu - discarding %u buffered bytes",
-                         (unsigned long)size, (unsigned)ml->lp_acc_len);
+                ESP_LOGW(TAG, "long-poll: implausible message size %lu ('%c%c%c%c') - "
+                              "discarding %u buffered bytes",
+                         (unsigned long)size,
+                         isprint(m[0]) ? m[0] : '.', isprint(m[1]) ? m[1] : '.',
+                         isprint(m[2]) ? m[2] : '.', isprint(m[3]) ? m[3] : '.',
+                         (unsigned)ml->lp_acc_len);
                 ml->lp_acc_len = 0;
                 consumed = 0;
                 break;

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -2995,7 +2995,14 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
     struct timeval tv_recv = { .tv_sec = 2, .tv_usec = 0 };
     ml_setsockopt(ml_conn_sockfd(ml), SOL_SOCKET, SO_RCVTIMEO, &tv_recv, sizeof(tv_recv));
 
-    uint8_t *frame_buf = ml_psram_malloc(65536);
+    /* 65536 for the read itself, plus room for a carried partial frame in front
+     * of it. noise_recv() abandons a frame mid-stream if its plaintext exceeds
+     * the window it was given (it has already consumed the Noise header by
+     * then), so the window must never shrink below the largest plaintext the
+     * peer can send. Sizing the buffer this way keeps the recv window at a full
+     * 65536 no matter how much is carried. */
+    const size_t frame_cap = 65536 + ML_H2_MAX_FRAME_LEN + 9;
+    uint8_t *frame_buf = ml_psram_malloc(frame_cap);
     if (!frame_buf) return 0;
 
     /* Prepend bytes left over from the previous read. An H2 DATA frame whose
@@ -3005,12 +3012,12 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
     size_t carry = 0;
     if (ml->h2_acc && ml->h2_acc_len > 0) {
         carry = ml->h2_acc_len;
-        if (carry > 65536) carry = 0;          /* cannot happen; be safe */
+        if (carry > frame_cap) carry = 0;      /* cannot happen; be safe */
         if (carry) memcpy(frame_buf, ml->h2_acc, carry);
         ml->h2_acc_len = 0;
     }
 
-    int rcvd = noise_recv(ml, noise, frame_buf + carry, 65536 - carry);
+    int rcvd = noise_recv(ml, noise, frame_buf + carry, (int)(frame_cap - carry));
     int frame_len = (rcvd > 0) ? rcvd + (int)carry : rcvd;
 
     if (rcvd <= 0 && carry > 0) {
@@ -3027,6 +3034,7 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
     }
 
     /* Extract DATA frame payload from H2 frames, track flow control */
+    bool proto_err = false;
     uint32_t total_data_bytes = 0;
     uint32_t data_stream_id = 0;
     int pos = 0;
@@ -3044,10 +3052,17 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
          * the read window to zero and stall until the watchdog fires. Treat an
          * unsatisfiable frame as a protocol error. */
         if (f_len > ML_H2_MAX_FRAME_LEN) {
-            ESP_LOGE(TAG, "H2 frame length %lu exceeds %d - protocol error, dropping session state",
-                     (unsigned long)f_len, ML_H2_MAX_FRAME_LEN);
+            ESP_LOGE(TAG, "H2 frame length %lu exceeds %d - framing is unrecoverable, "
+                          "dropping the session", (unsigned long)f_len, ML_H2_MAX_FRAME_LEN);
             ml->h2_acc_len = 0;
             ml->lp_acc_len = 0;
+            /* Do NOT fall through to the trailing-bytes carry below: `pos` is
+             * already past this frame's header and its payload is still in the
+             * buffer, so carrying it would re-inject the very bytes we just
+             * rejected and desync every subsequent read. Once H2 framing is
+             * lost there is no way back within the session - close it and let
+             * the coord state machine reconnect. */
+            proto_err = true;
             break;
         }
 
@@ -3105,7 +3120,7 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
     /* A read can also end mid-HEADER (1-8 bytes of the 9-byte prefix). The loop
      * above stops on `pos + 9 <= frame_len`, so those bytes would be dropped and
      * desynchronise the stream exactly as a split payload does. Carry them too. */
-    if (pos < frame_len && ml->h2_acc_len == 0) {
+    if (!proto_err && pos < frame_len && ml->h2_acc_len == 0) {
         size_t left = (size_t)frame_len - (size_t)pos;
         if (!ml->h2_acc) ml->h2_acc = ml_psram_malloc(65536);
         if (ml->h2_acc && left <= 65536) {
@@ -3152,7 +3167,10 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
                             ((uint32_t)m[2] << 16) | ((uint32_t)m[3] << 24);
             /* A size we could never satisfy means we are out of frame. Losing one update is
              * recoverable; a permanently stuck accumulator is not. */
-            if (size == 0 || size > ML_JSON_BUFFER_SIZE) {
+            /* Must be `- 4`: the accumulator holds ML_JSON_BUFFER_SIZE bytes and
+             * a message occupies 4 + size, so anything larger can never complete
+             * and would churn the buffer forever. */
+            if (size == 0 || size > ML_JSON_BUFFER_SIZE - 4) {
                 ESP_LOGW(TAG, "long-poll: implausible message size %lu ('%c%c%c%c') - "
                               "discarding %u buffered bytes",
                          (unsigned long)size,
@@ -3185,6 +3203,7 @@ static int poll_map_update(microlink_t *ml, ml_noise_state_t *noise) {
     }
 
     free(frame_buf);
+    if (proto_err) return -1;   /* caller closes the connection and reconnects */
     return 1;
 }
 

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -1604,6 +1604,9 @@ static int do_register(microlink_t *ml, ml_noise_state_t *noise) {
  * State: FETCH_PEERS - Send MapRequest, parse MapResponse
  * ========================================================================== */
 
+/* Defined below with the long-poll reader; both map paths share one framed stream. */
+static void lp_acc_append(microlink_t *ml, const uint8_t *data, size_t len);
+
 static void parse_peers_from_map_response(microlink_t *ml, cJSON *root) {
     /* Try all field names used by Tailscale (copied from v1 lines 3176-3184):
      *   "Peers"        - Full peer list (initial Stream=false response)
@@ -2476,41 +2479,56 @@ static int do_map_exchange(microlink_t *ml, ml_noise_state_t *noise, bool send_r
         ESP_LOGI(TAG, "MapResponse first %d bytes (hex): %s", dump, hexbuf);
     }
 
-    /* Check for length prefix (Tailscale binary framing: 4-byte big-endian length before JSON) */
+    /* Framed read, per tailscale/control/controlclient/direct.go:1294-1311. The reference
+     * uses ONE reader for both cases and says so explicitly:
+     *
+     *     // If allowStream, then the server will use an HTTP long poll to
+     *     // return incremental results. There is always one response right
+     *     // away, followed by a delay, and eventually others.
+     *     // If !allowStream, it'll still send the first result in exactly
+     *     // the same format before just closing the connection.
+     *     // We can use this same read loop either way.
+     *     var siz [4]byte; io.ReadFull(res.Body, siz[:])
+     *     size := binary.LittleEndian.Uint32(siz[:])
+     *     msg = append(msg[:0], make([]byte, size)...); io.ReadFull(res.Body, msg)
+     *
+     * So EVERY message on this path is 4-byte little-endian length + that many bytes,
+     * streamed or not. This previously sniffed for '{' in the first 8 bytes, probed BOTH
+     * endiannesses, clamped to the first message and then DISCARDED the remainder - which
+     * left the long-poll reader starting mid-message on its very first read.
+     *
+     * Now: read the length, parse exactly that message, and hand any trailing bytes to the
+     * long-poll accumulator so the two paths form one continuous framed stream. */
     char *parse_start = (char *)resp_buf;
     size_t parse_len = json_total;
 
-    /* Find the start of JSON - look for '{' in first 8 bytes */
-    int json_offset = -1;
-    for (int i = 0; i < 8 && i < (int)json_total; i++) {
-        if (resp_buf[i] == '{') {
-            json_offset = i;
-            break;
-        }
-    }
-    if (json_offset > 0) {
-        ESP_LOGI(TAG, "JSON starts at offset %d (skipping %d-byte prefix)", json_offset, json_offset);
-        parse_start += json_offset;
-        parse_len -= json_offset;
-    } else if (json_offset < 0) {
-        ESP_LOGW(TAG, "No '{' found in first 8 bytes of MapResponse!");
-    }
-
-    /* Stream mode: the buffer may already hold the START of the next
-     * length-prefixed message behind the first one — clamp parsing to the
-     * first message, or cJSON chokes on the trailing bytes. */
-    if (!send_request && json_offset == 4 && json_total > 4) {
-        uint32_t le = (uint32_t)resp_buf[0] | ((uint32_t)resp_buf[1] << 8) |
-                      ((uint32_t)resp_buf[2] << 16) | ((uint32_t)resp_buf[3] << 24);
-        uint32_t be = ((uint32_t)resp_buf[0] << 24) | ((uint32_t)resp_buf[1] << 16) |
-                      ((uint32_t)resp_buf[2] << 8) | (uint32_t)resp_buf[3];
-        uint32_t body = 0;
-        if (le >= 2 && le <= parse_len) body = le;
-        else if (be >= 2 && be <= parse_len) body = be;
-        if (body > 0 && body < parse_len) {
-            ESP_LOGI(TAG, "Clamping streamed MapResponse parse to first message (%lu of %lu bytes)",
-                     (unsigned long)body, (unsigned long)parse_len);
-            parse_len = body;
+    if (json_total >= 4) {
+        uint32_t size = (uint32_t)resp_buf[0] | ((uint32_t)resp_buf[1] << 8) |
+                        ((uint32_t)resp_buf[2] << 16) | ((uint32_t)resp_buf[3] << 24);
+        if (size >= 2 && (size_t)size <= json_total - 4) {
+            parse_start = (char *)resp_buf + 4;
+            parse_len = size;
+            size_t rest_off = 4 + (size_t)size;
+            if (rest_off < json_total) {
+                /* Tail belongs to the NEXT message - carry it, do not drop it. */
+                ESP_LOGI(TAG, "MapResponse: %lu-byte message, %u trailing byte(s) carried to long-poll",
+                         (unsigned long)size, (unsigned)(json_total - rest_off));
+                lp_acc_append(ml, resp_buf + rest_off, json_total - rest_off);
+            }
+        } else {
+            /* No usable prefix. Fall back to the old '{' sniff so a control plane that
+             * frames differently still works, but say so - it should not happen. */
+            int json_offset = -1;
+            for (int k = 0; k < 8 && k < (int)json_total; k++) {
+                if (resp_buf[k] == '{') { json_offset = k; break; }
+            }
+            ESP_LOGW(TAG, "MapResponse: no valid length prefix (size=%lu, have %u) - "
+                          "falling back to '{' sniff at offset %d",
+                     (unsigned long)size, (unsigned)json_total, json_offset);
+            if (json_offset > 0) {
+                parse_start += json_offset;
+                parse_len   -= json_offset;
+            }
         }
     }
 


### PR DESCRIPTION
Rebased onto v0.5.5. This is the first of the six findings, taken in the priority order you gave in #33.

## The symptom

Deterministic, ~41 s after every boot, on every build:

```
long-poll: implausible message size 808333626 (':1.0') - discarding 334 bytes
long-poll: implausible message size 573583665 ('110"') - discarding 358 bytes
```

Those "sizes" are ASCII from the middle of a JSON body read as a little-endian uint32, so something was starting mid-message. I rewrote the message framing twice before dumping the bytes and finding the actual layer: **HTTP/2 DATA frames split across reads were not being reassembled**, so the accumulator began mid-frame and mis-read JSON as a length prefix.

This is deterministic on any tailnet whose netmap is large enough to span DATA frames, and since the client sends `Compress: ""` it gets more likely as a tailnet grows.

## What the series does

- Reassemble H2 frames across reads, and accumulate **every** stream-5 DATA frame in a read, not just the last one.
- One framed reader for both map paths, so the initial netmap and the long-poll form a single continuous stream instead of the first read clamping to one message and discarding the remainder.
- Read the length prefix as **little-endian** everywhere, per `control/controlclient/direct.go:1303-1311`. The completion detector previously probed both endiannesses and took whichever looked larger, which can overestimate how long to wait.

## Defects found reviewing the series against the reference, and fixed here

1. **One-byte out-of-bounds write.** `lp_acc` is allocated at exactly `ML_JSON_BUFFER_SIZE` and the append guard let `lp_acc_len` reach it, so a message ending exactly at the buffer end wrote its NUL terminator one byte past the allocation. `size` comes off the wire.
2. **A read ending mid-HEADER lost bytes.** The frame walk stops on `pos + 9 <= frame_len`, so 1-8 trailing bytes of a 9-byte header were dropped, desynchronising the stream the same way a split payload did.
3. **No bound on frame length.** The wire field is 24-bit, so a frame can claim up to 16 MB, which can never be satisfied from a 64 KB read buffer; the carry logic would shrink the read window toward zero and stall until the watchdog fired.
4. **Reassembly state survived a reconnect.** `ml_conn_close()` cleared the socket and TLS handle but not `h2_acc_len`/`lp_acc_len`, so leftover bytes from a dead session prepended the next session's first framed message - the initial full netmap.
5. **The oversized-frame guard made things worse than doing nothing** - it fell through to the trailing-bytes carry, re-injecting the very bytes it had just rejected. It now sets `proto_err` and closes the session: once H2 framing is lost there is no recovery within it.
6. **The drain guard and the message limit disagreed** - it accepted `size <= ML_JSON_BUFFER_SIZE`, but a message occupies `4 + size`, so anything in the top four bytes could never complete and churned the accumulator.
7. **Carrying a partial frame shrank the `noise_recv` window below 65536**, which `noise_recv` cannot survive mid-frame. `frame_buf` is now sized `65536 + ML_H2_MAX_FRAME_LEN + 9` so the window stays at a full 65536 regardless of carry.

## Testing

Running on two ESP32-S3 boards on an ~85-node Tailscale SaaS tailnet, which is what made this reproduce every boot. Happy to field-test anything further - and the standing offer on the symmetric-NAT site holds for the home-DERP PR when we get to it.