### PR TITLE
fix: choose our own home DERP from netcheck, and announce before moving

### DIFF
--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -121,8 +121,10 @@ extern "C" {
 /* Stop probing a peer whose WireGuard session has carried no traffic for this
  * long. From tailscale/wgengine/magicsock/magicsock.go:4014
  * (sessionActiveTimeout): the reference ends heartbeats for an idle session
- * rather than probing peers it is not talking to. */
-#define ML_DISCO_SESSION_ACTIVE_MS      45000
+ * rather than probing peers it is not talking to.
+ *
+ * This constant already existed here, defined and never used - like
+ * derp.last_recv_ms before the liveness watchdog. Now wired up. */
 #define ML_DISCO_SESSION_ACTIVE_MS      45000
 
 /* STUN servers (Tailscale primary, Google fallback) */

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -339,6 +339,11 @@ typedef struct {
      * (e.g. both ends behind the same NAT with no hairpin, or VLAN-isolated). */
     uint64_t peer_added_ms;        /* When this peer entered our state */
     bool derp_fallback_active;     /* Endpoint forced to DERP via update_endpoint(0) */
+
+    /* Set when a relay reports PeerGone for this peer: it has no path there,
+     * so driving handshakes through it is waste. Suppress retries until this
+     * time, then try again in case the peer has come back. */
+    uint64_t derp_gone_until_ms;
     uint64_t last_derp_attempt_ms; /* Last wireguardif_connect_derp() retry, for periodic re-fire */
 
     /* Exit-node advertisement (Phase 1.5e): true if this peer carries
@@ -381,6 +386,11 @@ typedef struct {
  * (PreferredDERPFrameTime). Without this a working region that loses one round
  * of STUN probes reads as dead, and home moves with no hysteresis at all. */
 #define ML_DERP_PREFERRED_FRAME_MS   8000
+
+/* How long to stop driving WireGuard handshakes through a relay that has told
+ * us it has no path to the peer (DERP PeerGone). Long enough to stop the waste,
+ * short enough that a peer coming back is picked up quickly. */
+#define ML_DERP_GONE_BACKOFF_MS      60000
 #define ML_MAX_DERP_NODES       4
 
 typedef struct {

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -717,6 +717,9 @@ void ml_bind_sock_to_upstream(microlink_t *ml, int fd);
 /* ml_wg_mgr.c */
 void ml_wg_mgr_task(void *arg);
 void ml_wg_mgr_send_cmm(microlink_t *ml, uint32_t peer_vpn_ip);
+/* Called from the DERP task when a relay reports PeerGone for a peer: it has
+ * no path there, so stop driving handshakes through it for a while. */
+void ml_wg_mgr_notify_derp_gone(microlink_t *ml, const uint8_t *public_key);
 esp_err_t ml_wg_mgr_trigger_handshake(microlink_t *ml, uint32_t dest_vpn_ip);
 bool ml_wg_mgr_peer_is_up(microlink_t *ml, uint32_t vpn_ip);
 

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -566,6 +566,12 @@ struct microlink_s {
      * Slot 0 is the newest; the ring is rotated on each netcheck. */
     uint16_t derp_rtt_hist[ML_DERP_RTT_HISTORY][ML_MAX_DERP_REGIONS];
 
+    /* History slots are indexed by position in derp_regions[], so they are only
+     * meaningful while that array's contents are unchanged. Checksum the region
+     * IDs and discard the history whenever the DERPMap changes, rather than
+     * silently attributing one region's latency to another. */
+    uint32_t derp_region_sig;
+
     /* The region WE have chosen as home, from our own measurements. This is
      * what gets reported to the control plane in NetInfo.PreferredDERP. */
     uint16_t derp_preferred_region;

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -375,6 +375,12 @@ typedef struct {
 #define ML_DERP_SWITCH_MIN_DIFF_MS   10     /* preferredDERPAbsoluteDiff */
 #define ML_DERP_SWITCH_RATIO_NUM     2      /* new must be <= old * 2/3 */
 #define ML_DERP_SWITCH_RATIO_DEN     3
+
+/* A region is still considered reachable if we have heard from it by a
+ * NON-STUN route this recently. tailscale/net/netcheck/netcheck.go:1381
+ * (PreferredDERPFrameTime). Without this a working region that loses one round
+ * of STUN probes reads as dead, and home moves with no hysteresis at all. */
+#define ML_DERP_PREFERRED_FRAME_MS   8000
 #define ML_MAX_DERP_NODES       4
 
 typedef struct {

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -367,6 +367,14 @@ typedef struct {
  * ========================================================================== */
 
 #define ML_MAX_DERP_REGIONS     32
+#define ML_DERP_RTT_HISTORY      3      /* netchecks kept for best-recent latency */
+
+/* Home-DERP stickiness, from tailscale/net/netcheck/netcheck.go:1376-1381.
+ * Changing home DERP is disruptive (peers must be told), so a new region must
+ * be better by BOTH an absolute margin AND a proportional one. */
+#define ML_DERP_SWITCH_MIN_DIFF_MS   10     /* preferredDERPAbsoluteDiff */
+#define ML_DERP_SWITCH_RATIO_NUM     2      /* new must be <= old * 2/3 */
+#define ML_DERP_SWITCH_RATIO_DEN     3
 #define ML_MAX_DERP_NODES       4
 
 typedef struct {
@@ -545,6 +553,17 @@ struct microlink_s {
      * Same index as derp_regions; 0 = no measurement / timed out. */
     uint16_t derp_rtt_ms[ML_MAX_DERP_REGIONS];
 
+    /* Best-recent latency per region, across the last ML_DERP_RTT_HISTORY
+     * netchecks. The reference selects on the best latency seen over a recent
+     * window rather than the newest single probe, so one unlucky sample cannot
+     * move our home region (net/netcheck/netcheck.go:1525 bestRecentLatencyLocked).
+     * Slot 0 is the newest; the ring is rotated on each netcheck. */
+    uint16_t derp_rtt_hist[ML_DERP_RTT_HISTORY][ML_MAX_DERP_REGIONS];
+
+    /* The region WE have chosen as home, from our own measurements. This is
+     * what gets reported to the control plane in NetInfo.PreferredDERP. */
+    uint16_t derp_preferred_region;
+
     /* ml_get_time_ms() value when state transitioned to CONNECTED. 0 means
      * not currently connected. Used for the GUI tailnet uptime row. */
     uint64_t connected_at_ms;
@@ -678,6 +697,9 @@ esp_err_t ml_stun_send_probe_ipv6(microlink_t *ml, const uint8_t *server_ip6, ui
  * a STUN binding request in parallel, measures RTT, returns the
  * region_id with the lowest RTT. Returns 0 if nothing responded. */
 uint16_t ml_netcheck_pick_best_derp(microlink_t *ml);
+void     ml_netcheck_record_history(microlink_t *ml);
+uint16_t ml_netcheck_best_recent_rtt(const microlink_t *ml, uint16_t region);
+uint16_t ml_netcheck_best_recent_region(const microlink_t *ml);
 bool ml_stun_parse_response(const uint8_t *data, size_t len,
                              uint32_t *out_ip, uint16_t *out_port);
 bool ml_stun_parse_response_ipv6(const uint8_t *data, size_t len,

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -576,6 +576,11 @@ struct microlink_s {
      * what gets reported to the control plane in NetInfo.PreferredDERP. */
     uint16_t derp_preferred_region;
 
+    /* Set when derp_preferred_region changes: the control plane must be told
+     * promptly, because until it is, peers are still being advertised the old
+     * home region and cannot reach us. */
+    bool derp_home_pending_report;
+
     /* ml_get_time_ms() value when state transitioned to CONNECTED. 0 means
      * not currently connected. Used for the GUI tailnet uptime row. */
     uint64_t connected_at_ms;

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -117,6 +117,12 @@ extern "C" {
 #define ML_DISCO_TRUST_DURATION_MS      60000
 #define ML_DISCO_PING_TIMEOUT_MS        5000
 #define ML_DISCO_UPGRADE_INTERVAL_MS    15000
+
+/* Stop probing a peer whose WireGuard session has carried no traffic for this
+ * long. From tailscale/wgengine/magicsock/magicsock.go:4014
+ * (sessionActiveTimeout): the reference ends heartbeats for an idle session
+ * rather than probing peers it is not talking to. */
+#define ML_DISCO_SESSION_ACTIVE_MS      45000
 #define ML_DISCO_SESSION_ACTIVE_MS      45000
 
 /* STUN servers (Tailscale primary, Google fallback) */

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -82,6 +82,7 @@ extern "C" {
 #define ML_STUN_RX_QUEUE_DEPTH  4
 #define ML_COORD_CMD_QUEUE_DEPTH 4
 #define ML_PEER_UPDATE_QUEUE_DEPTH 400
+#define ML_DERP_GONE_QUEUE_DEPTH 64
 
 /* Protocol limits */
 #define ML_MAX_PEERS            CONFIG_ML_MAX_PEERS
@@ -325,6 +326,7 @@ typedef struct {
     uint64_t last_pong_recv_ms;     /* Last DISCO pong we received */
     uint64_t trust_until_ms;        /* Direct path trusted until */
     uint64_t last_send_ms;          /* Last data sent to this peer */
+    uint64_t last_data_recv_ms;     /* Last inbound WG packet seen (wg_mgr-owned, idle-gate) */
     uint64_t last_upgrade_ms;       /* Last path upgrade attempt */
 
     /* Best direct path */
@@ -503,6 +505,7 @@ struct microlink_s {
     QueueHandle_t stun_rx_queue;        /* net_io -> coord */
     QueueHandle_t coord_cmd_queue;      /* any -> coord */
     QueueHandle_t peer_update_queue;    /* coord -> wg_mgr */
+    QueueHandle_t derp_gone_queue;      /* DERP RX task -> wg_mgr (32-byte peer key) */
 
     /* Keys (loaded at init, read-only after) */
     uint8_t machine_private_key[32];    /* Noise machine key */

--- a/microlink/components/microlink/src/microlink.c
+++ b/microlink/components/microlink/src/microlink.c
@@ -350,6 +350,7 @@ microlink_t *microlink_init(const microlink_config_t *config) {
     ml->stun_rx_queue = xQueueCreate(ML_STUN_RX_QUEUE_DEPTH, sizeof(ml_rx_packet_t));
     ml->coord_cmd_queue = xQueueCreate(ML_COORD_CMD_QUEUE_DEPTH, sizeof(ml_coord_cmd_t));
     ml->peer_update_queue = xQueueCreate(ML_PEER_UPDATE_QUEUE_DEPTH, sizeof(ml_peer_update_t *));
+    ml->derp_gone_queue = xQueueCreate(ML_DERP_GONE_QUEUE_DEPTH, 32);
 
     if (!ml->derp_tx_queue || !ml->disco_rx_queue || !ml->wg_rx_queue ||
         !ml->stun_rx_queue || !ml->coord_cmd_queue || !ml->peer_update_queue) {
@@ -581,6 +582,7 @@ void microlink_destroy(microlink_t *ml) {
     if (ml->stun_rx_queue) vQueueDelete(ml->stun_rx_queue);
     if (ml->coord_cmd_queue) vQueueDelete(ml->coord_cmd_queue);
     if (ml->peer_update_queue) vQueueDelete(ml->peer_update_queue);
+    if (ml->derp_gone_queue) vQueueDelete(ml->derp_gone_queue);
 
     /* Delete event group */
     if (ml->events) vEventGroupDelete(ml->events);

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -2231,12 +2231,25 @@ static bool parse_derp_map_from_response(microlink_t *ml, cJSON *map_json) {
                 }
             }
             if (ml->derp_preferred_region != prev && ml->derp_preferred_region != 0) {
-                /* Report the new region immediately. Until the control plane
-                 * has it, peers are still being told to reach us at the old
-                 * one, so every second of delay is a second of unreachability. */
+                /* Announce BEFORE moving. Peers reach us at the HomeDERP the
+                 * control plane advertises, which it derives from the
+                 * PreferredDERP we report. If we switch our own connection
+                 * first, we stop listening where everyone is still calling and
+                 * go dark until the new region propagates - observed as several
+                 * minutes of unreachability on a relay-only board.
+                 *
+                 * The reference can move immediately because magicsock keeps
+                 * connections to several regions and prunes idle ones later
+                 * (wgengine/magicsock/derp.go). We hold exactly one, so the
+                 * equivalent is to stay on the old relay until control has been
+                 * told, and only then move. derp_home_region is therefore NOT
+                 * updated here - the coord loop applies it once the endpoint
+                 * update has actually gone out. */
                 ml->derp_home_pending_report = true;
+            } else {
+                /* No change, or nothing chosen yet: keep them in step. */
+                ml->derp_home_region = ml->derp_preferred_region;
             }
-            ml->derp_home_region = ml->derp_preferred_region;
         }
     }
 
@@ -3521,12 +3534,23 @@ void ml_coord_task(void *arg) {
                  * lands, every peer is still dialling the old region. */
                 if (ml->derp_home_pending_report) {
                     ml->derp_home_pending_report = false;
-                    ESP_LOGW(TAG, "Home DERP changed to %u - reporting to control plane now",
-                             ml->derp_preferred_region);
+                    ESP_LOGW(TAG, "Announcing home DERP %u to control (still on %u)",
+                             ml->derp_preferred_region, ml->derp_home_region);
                     if (do_send_endpoint_update(ml, &noise) < 0) {
-                        /* Could not tell control. Try again next iteration
-                         * rather than leaving peers pointed at the old region. */
+                        /* Could not tell control. Stay where we are and retry:
+                         * moving now would take us off the relay peers are
+                         * still being pointed at. */
                         ml->derp_home_pending_report = true;
+                    } else {
+                        /* Control has our new PreferredDERP. Only now move our
+                         * own connection, so we are never listening somewhere
+                         * nobody has been told about. */
+                        if (ml->derp_home_region != ml->derp_preferred_region) {
+                            ESP_LOGW(TAG, "Announced - moving home DERP %u -> %u",
+                                     ml->derp_home_region, ml->derp_preferred_region);
+                            ml->derp_home_region = ml->derp_preferred_region;
+                            xEventGroupSetBits(ml->events, ML_EVT_DERP_RECONNECT);
+                        }
                     }
                 }
 

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -2629,8 +2629,22 @@ static int do_map_exchange(microlink_t *ml, ml_noise_state_t *noise, bool send_r
              * then fall back to legacy DERP string (format: "127.3.3.40:REGION") */
             cJSON *home_derp = cJSON_GetObjectItem(node, "HomeDERP");
             if (home_derp && cJSON_IsNumber(home_derp) && home_derp->valueint > 0) {
-                ml->derp_home_region = (uint16_t)home_derp->valueint;
-                ESP_LOGI(TAG, "Home DERP region: %d (from server, HomeDERP)", ml->derp_home_region);
+                /* Node.HomeDERP is the control plane echoing back the
+                 * PreferredDERP we reported - it is NOT an independent
+                 * suggestion. Adopting it unconditionally undoes our own
+                 * netcheck selection: after we pick a nearer region, the next
+                 * netmap still carries the previous value (control has not
+                 * processed our report yet) and would flip the ACTIVE region
+                 * back, which is the very mismatch this series set out to fix.
+                 * Take it only as a seed when we have no region at all. */
+                if (ml->derp_home_region == 0) {
+                    ml->derp_home_region = (uint16_t)home_derp->valueint;
+                    ESP_LOGI(TAG, "Home DERP region: %d (seed from server echo)",
+                             ml->derp_home_region);
+                } else if ((uint16_t)home_derp->valueint != ml->derp_home_region) {
+                    ESP_LOGI(TAG, "Server echo HomeDERP=%d differs from our choice %u - keeping ours",
+                             home_derp->valueint, ml->derp_home_region);
+                }
             } else {
                 cJSON *self_derp = cJSON_GetObjectItem(node, "DERP");
                 if (self_derp && self_derp->valuestring) {

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -2137,6 +2137,27 @@ static bool parse_derp_map_from_response(microlink_t *ml, cJSON *map_json) {
             uint16_t prev_rtt = (prev > 0) ? ml_netcheck_best_recent_rtt(ml, prev) : 0;
             bool prev_reachable = (prev > 0 && prev_rtt > 0);
 
+            /* A lost STUN probe is not proof a region is down. The reference
+             * also treats the old region as alive if it has heard from it by a
+             * non-STUN route within PreferredDERPFrameTime (netcheck.go:1471-1484):
+             *
+             *     heardFromOldRegionRecently = prevRegionLastHeard.After(rs.start)
+             *       || prevRegionLastHeard.After(now.Add(-PreferredDERPFrameTime))
+             *     oldRegionIsAccessible := oldRegionCurLatency != 0 || heardFromOldRegionRecently
+             *
+             * Our equivalent: an established DERP session to that same region
+             * that has received traffic recently. This matters because the
+             * !prev_reachable path below moves home with NO hysteresis. */
+            if (!prev_reachable && prev > 0 && prev == ml->derp_home_region &&
+                ml->derp.connected && ml->derp.last_recv_ms != 0) {
+                uint64_t since_rx = ml_get_time_ms() - ml->derp.last_recv_ms;
+                if (since_rx <= ML_DERP_PREFERRED_FRAME_MS) {
+                    ESP_LOGI(TAG, "Region %u missed STUN but its DERP session had traffic %llums ago - still alive",
+                             prev, (unsigned long long)since_rx);
+                    prev_reachable = true;
+                }
+            }
+
             if (!prev_reachable || prev == 0) {
                 /* No usable current home - take the best we can see. */
                 if (best != prev) {

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -2132,6 +2132,35 @@ static bool parse_derp_map_from_response(microlink_t *ml, cJSON *map_json) {
         uint16_t best = ml_netcheck_best_recent_region(ml);
         if (best == 0) best = measured;
 
+        /* Do NOT move an established home region while we have no live long
+         * poll to the control plane. Peers reach a node at the HomeDERP the
+         * control plane advertises for it, so a home change we cannot report
+         * does not improve connectivity - it removes it, and the node becomes
+         * unreachable to every peer until the advertisement propagates. On a
+         * relay-only device that is the difference between a latency win and
+         * losing the device entirely.
+         *
+         * The reference refuses the same way (wgengine/magicsock/derp.go:177-190):
+         *
+         *     connectedToControl = c.health.GetInPollNetMap()
+         *     if !connectedToControl && !force {
+         *         if myDerp != 0 { return myDerp }   // keep what we have
+         *         // else fall through: any DERP beats none
+         *     }
+         *
+         * GetInPollNetMap is "the client has an open HTTP long poll to the
+         * control plane" (health/health.go:770-779); ctrl_stream_rx_ms is our
+         * equivalent, fed by every frame on the map stream. Having NO home at
+         * all is the documented exception - any relay beats none. */
+        bool in_map_poll = (ml->ctrl_stream_rx_ms != 0) &&
+                           ((ml_get_time_ms() - ml->ctrl_stream_rx_ms) < ML_CTRL_STREAM_STALE_MS);
+        if (!in_map_poll && prev != 0 && best != prev) {
+            ESP_LOGW(TAG, "Home DERP would change %u -> %u, but the control-plane map "
+                          "stream is not live - keeping %u so peers can still reach us",
+                     prev, best, prev);
+            best = prev;
+        }
+
         if (best > 0) {
             uint16_t best_rtt = ml_netcheck_best_recent_rtt(ml, best);
             uint16_t prev_rtt = (prev > 0) ? ml_netcheck_best_recent_rtt(ml, prev) : 0;
@@ -2185,6 +2214,12 @@ static bool parse_derp_map_from_response(microlink_t *ml, cJSON *map_json) {
                              big_enough ? "not proportionally better" : "margin too small");
                     ml->derp_preferred_region = prev;
                 }
+            }
+            if (ml->derp_preferred_region != prev && ml->derp_preferred_region != 0) {
+                /* Report the new region immediately. Until the control plane
+                 * has it, peers are still being told to reach us at the old
+                 * one, so every second of delay is a second of unreachability. */
+                ml->derp_home_pending_report = true;
             }
             ml->derp_home_region = ml->derp_preferred_region;
         }
@@ -3463,6 +3498,21 @@ void ml_coord_task(void *arg) {
                         do_send_endpoint_update(ml, &noise);
                     }
                     free(stun_pkt.data);
+                }
+
+                /* A home-region change must reach the control plane at once:
+                 * peers are told where to find us via Node.HomeDERP, which
+                 * control derives from the PreferredDERP we report. Until this
+                 * lands, every peer is still dialling the old region. */
+                if (ml->derp_home_pending_report) {
+                    ml->derp_home_pending_report = false;
+                    ESP_LOGW(TAG, "Home DERP changed to %u - reporting to control plane now",
+                             ml->derp_preferred_region);
+                    if (do_send_endpoint_update(ml, &noise) < 0) {
+                        /* Could not tell control. Try again next iteration
+                         * rather than leaving peers pointed at the old region. */
+                        ml->derp_home_pending_report = true;
+                    }
                 }
 
                 /* STUN retry logic: 3 attempts per server, 2s apart, then fallback */

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -1270,7 +1270,20 @@ static int do_register(microlink_t *ml, ml_noise_state_t *noise) {
     {
         cJSON *netinfo = cJSON_CreateObject();
         if (netinfo) {
-            cJSON_AddNumberToObject(netinfo, "PreferredDERP", ml->derp_region_default);
+            /* Report the region WE picked from our own netcheck. Sending
+             * derp_region_default here is circular: the control plane echoes
+             * whatever we send back as Node.HomeDERP, we then adopt that echo
+             * as our default, and send it again - so an initially wrong region
+             * is self-sustaining and can never be measured away. Worse, peers
+             * are told to reach us at that wrong region.
+             *
+             * The reference picks its home DERP from its own netcheck report
+             * (magicsock/derp.go:197 preferredDERP = report.PreferredDERP) and
+             * informs control; control never dictates it. */
+            uint16_t report_derp = ml->derp_preferred_region;
+            if (report_derp == 0) report_derp = ml->derp_home_region;
+            if (report_derp == 0) report_derp = ml->derp_region_default;
+            cJSON_AddNumberToObject(netinfo, "PreferredDERP", report_derp);
             cJSON_AddItemToObject(hostinfo, "NetInfo", netinfo);
         }
     }
@@ -2107,30 +2120,52 @@ static bool parse_derp_map_from_response(microlink_t *ml, cJSON *map_json) {
      *       Sao Paulo 86 ms with a 50 ms threshold = stay on FFM). */
     if (ml->derp_region_count > 0) {
         uint16_t measured = ml_netcheck_pick_best_derp(ml);
-        uint16_t cp = ml->derp_region_default;
 
-        if (!ml->config.netcheck_override_enabled) {
-            ESP_LOGI(TAG, "Netcheck override disabled by config — using control-plane DERP %u", cp);
-        } else if (measured > 0 && measured != cp) {
-            /* Look up RTTs from ml->derp_rtt_ms (aligned with derp_regions[]). */
-            uint16_t measured_rtt = 0, cp_rtt = 0;
-            for (int r = 0; r < ml->derp_region_count; r++) {
-                if (ml->derp_regions[r].region_id == measured) measured_rtt = ml->derp_rtt_ms[r];
-                if (ml->derp_regions[r].region_id == cp) cp_rtt = ml->derp_rtt_ms[r];
-            }
-            bool cp_has_rtt = (cp != 0 && cp_rtt > 0);
-            int32_t improvement = cp_has_rtt ? (int32_t)cp_rtt - (int32_t)measured_rtt : INT32_MAX;
-            int32_t thresh = (int32_t)ml->config.netcheck_override_threshold_ms;
-            if (improvement >= thresh) {
-                ESP_LOGI(TAG, "Netcheck override: %u (%ums) -> %u (%ums), improvement %ldms >= %ldms threshold",
-                         cp, cp_rtt, measured, measured_rtt, (long)improvement, (long)thresh);
-                ml->derp_home_region = measured;
+        /* Fold this netcheck into the best-recent history and select on that,
+         * as the reference does (netcheck.go:1427-1500). Selection is ours to
+         * make; the control plane only relays what we report. */
+        ml_netcheck_record_history(ml);
+        uint16_t prev = ml->derp_preferred_region;
+        if (prev == 0) prev = ml->derp_home_region;
+        if (prev == 0) prev = ml->derp_region_default;
+
+        uint16_t best = ml_netcheck_best_recent_region(ml);
+        if (best == 0) best = measured;
+
+        if (best > 0) {
+            uint16_t best_rtt = ml_netcheck_best_recent_rtt(ml, best);
+            uint16_t prev_rtt = (prev > 0) ? ml_netcheck_best_recent_rtt(ml, prev) : 0;
+            bool prev_reachable = (prev > 0 && prev_rtt > 0);
+
+            if (!prev_reachable || prev == 0) {
+                /* No usable current home - take the best we can see. */
+                if (best != prev) {
+                    ESP_LOGI(TAG, "Home DERP: %u (%ums) - previous region %u not reachable",
+                             best, best_rtt, prev);
+                }
+                ml->derp_preferred_region = best;
+            } else if (best == prev) {
+                ml->derp_preferred_region = prev;
             } else {
-                ESP_LOGI(TAG, "Netcheck found %u (%ums) faster than CP %u (%ums) but improvement %ldms < %ldms threshold — staying on CP",
-                         measured, measured_rtt, cp, cp_rtt, (long)improvement, (long)thresh);
+                /* Stickiness: require BOTH an absolute and a proportional
+                 * improvement before moving, so we do not flap between two
+                 * similar regions (each move must be announced to peers). */
+                int32_t diff = (int32_t)prev_rtt - (int32_t)best_rtt;
+                bool big_enough  = diff >= ML_DERP_SWITCH_MIN_DIFF_MS;
+                bool much_better = (uint32_t)best_rtt * ML_DERP_SWITCH_RATIO_DEN <=
+                                   (uint32_t)prev_rtt * ML_DERP_SWITCH_RATIO_NUM;
+                if (big_enough && much_better) {
+                    ESP_LOGI(TAG, "Home DERP changing %u (%ums) -> %u (%ums): %ldms better, ratio ok",
+                             prev, prev_rtt, best, best_rtt, (long)diff);
+                    ml->derp_preferred_region = best;
+                } else {
+                    ESP_LOGI(TAG, "Home DERP staying %u (%ums); %u is %ums but %s",
+                             prev, prev_rtt, best, best_rtt,
+                             big_enough ? "not proportionally better" : "margin too small");
+                    ml->derp_preferred_region = prev;
+                }
             }
-        } else if (measured > 0 && measured == cp) {
-            ml->derp_home_region = measured;
+            ml->derp_home_region = ml->derp_preferred_region;
         }
     }
 
@@ -2809,7 +2844,20 @@ static int do_send_endpoint_update(microlink_t *ml, ml_noise_state_t *noise) {
 
         cJSON *netinfo = cJSON_CreateObject();
         if (netinfo) {
-            cJSON_AddNumberToObject(netinfo, "PreferredDERP", ml->derp_region_default);
+            /* Report the region WE picked from our own netcheck. Sending
+             * derp_region_default here is circular: the control plane echoes
+             * whatever we send back as Node.HomeDERP, we then adopt that echo
+             * as our default, and send it again - so an initially wrong region
+             * is self-sustaining and can never be measured away. Worse, peers
+             * are told to reach us at that wrong region.
+             *
+             * The reference picks its home DERP from its own netcheck report
+             * (magicsock/derp.go:197 preferredDERP = report.PreferredDERP) and
+             * informs control; control never dictates it. */
+            uint16_t report_derp = ml->derp_preferred_region;
+            if (report_derp == 0) report_derp = ml->derp_home_region;
+            if (report_derp == 0) report_derp = ml->derp_region_default;
+            cJSON_AddNumberToObject(netinfo, "PreferredDERP", report_derp);
             if (ml->stun_nat_checked) {
                 cJSON_AddBoolToObject(netinfo, "MappingVariesByDestIP", ml->nat_mapping_varies);
             }

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -2140,7 +2140,7 @@ static bool parse_derp_map_from_response(microlink_t *ml, cJSON *map_json) {
             if (!prev_reachable || prev == 0) {
                 /* No usable current home - take the best we can see. */
                 if (best != prev) {
-                    ESP_LOGI(TAG, "Home DERP: %u (%ums) - previous region %u not reachable",
+                    ESP_LOGW(TAG, "Home DERP: %u (%ums) - previous region %u not reachable",
                              best, best_rtt, prev);
                 }
                 ml->derp_preferred_region = best;
@@ -2155,7 +2155,7 @@ static bool parse_derp_map_from_response(microlink_t *ml, cJSON *map_json) {
                 bool much_better = (uint32_t)best_rtt * ML_DERP_SWITCH_RATIO_DEN <=
                                    (uint32_t)prev_rtt * ML_DERP_SWITCH_RATIO_NUM;
                 if (big_enough && much_better) {
-                    ESP_LOGI(TAG, "Home DERP changing %u (%ums) -> %u (%ums): %ldms better, ratio ok",
+                    ESP_LOGW(TAG, "Home DERP changing %u (%ums) -> %u (%ums): %ldms better, ratio ok",
                              prev, prev_rtt, best, best_rtt, (long)diff);
                     ml->derp_preferred_region = best;
                 } else {

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -2109,16 +2109,31 @@ static bool parse_derp_map_from_response(microlink_t *ml, cJSON *map_json) {
     }
     ESP_LOGI(TAG, "DERPMap: parsed %d regions", ml->derp_region_count);
 
-    /* Netcheck: measure RTT to every known DERP region via STUN.
-     * Whether we then override the control-plane HomeDERP is gated
-     * by two policy knobs (microlink_config_t):
-     *   netcheck_override_enabled  — kill switch
-     *   netcheck_override_threshold_ms — hysteresis: only switch
-     *       when the measured region beats the control-plane region
-     *       by at least N ms (avoids ping-ponging between regions
-     *       with near-identical latency, e.g. Frankfurt 100 ms vs
-     *       Sao Paulo 86 ms with a 50 ms threshold = stay on FFM). */
-    if (ml->derp_region_count > 0) {
+    /* Netcheck: measure RTT to every known DERP region via STUN, then choose
+     * our own home region from the result.
+     *
+     * netcheck_override_enabled still gates the CHOOSING, as it always has -
+     * with it false we keep the configured/default region. What is no longer
+     * gated is the REPORTING: NetInfo.PreferredDERP now always carries the
+     * region we are actually using rather than the control plane's echo of it,
+     * because that echo loop is a bug in either mode. Leaving it in place with
+     * the override off would still pin every device to whatever region it
+     * started on, which is what the flag's users are not asking for.
+     *
+     * netcheck_override_threshold_ms is superseded by the reference's two-part
+     * margin (absolute >= ML_DERP_SWITCH_MIN_DIFF_MS AND proportional <= 2/3),
+     * which is strictly more conservative than a single absolute threshold. */
+    if (ml->derp_region_count > 0 && !ml->config.netcheck_override_enabled &&
+        ml->derp_preferred_region == 0) {
+        /* Selection disabled: report the region we are actually using, so the
+         * echo loop is still broken even when we are not choosing. */
+        ml->derp_preferred_region = ml->derp_home_region ? ml->derp_home_region
+                                                         : ml->derp_region_default;
+        ESP_LOGI(TAG, "Netcheck selection disabled by config - reporting region %u",
+                 ml->derp_preferred_region);
+    }
+
+    if (ml->derp_region_count > 0 && ml->config.netcheck_override_enabled) {
         uint16_t measured = ml_netcheck_pick_best_derp(ml);
 
         /* Fold this netcheck into the best-recent history and select on that,

--- a/microlink/components/microlink/src/ml_derp.c
+++ b/microlink/components/microlink/src/ml_derp.c
@@ -373,7 +373,7 @@ static void dispatch_derp_frame(microlink_t *ml, uint8_t frame_type,
 
     case DERP_FRAME_HEALTH:
         /* Server telling us this connection is unhealthy. Its only current use
-         * upstream is duplicate-connection detection (derp.go:118-123) - two
+         * upstream is duplicate-connection detection (derp.go:117-122) - two
          * clients on one node key fighting over the same relay session, which
          * looks exactly like an unreachable node from the outside. Worth
          * seeing rather than dropping. */

--- a/microlink/components/microlink/src/ml_derp.c
+++ b/microlink/components/microlink/src/ml_derp.c
@@ -113,6 +113,7 @@ static int ml_derp_bio_send(void *ctx, const unsigned char *buf, size_t len) {
 #define DERP_FRAME_NOTE_PREFERRED 0x07
 #define DERP_FRAME_PEER_GONE    0x08
 #define DERP_FRAME_PING         0x12
+#define DERP_FRAME_HEALTH       0x14   /* server -> client: this connection is unhealthy */
 #define DERP_FRAME_PONG         0x13
 
 /* DISCO magic bytes: "TS" + sparkles emoji UTF-8 */
@@ -354,10 +355,33 @@ static void dispatch_derp_frame(microlink_t *ml, uint8_t frame_type,
         break;
 
     case DERP_FRAME_PEER_GONE:
+        /* 32-byte peer public key + 1 byte reason (derp.go:88). The reason
+         * matters: PeerGoneReasonNotHere (0x01) means this relay has no path
+         * to that peer at all, so continuing to drive WireGuard handshakes
+         * through it is pure waste. The reference removes its DERP route for
+         * the peer in every case (magicsock/derp.go:652-665). */
         if (payload && payload_len >= 32) {
-            ESP_LOGI(TAG, "DERP PeerGone: %02x%02x%02x%02x (len=%d)",
-                     payload[0], payload[1], payload[2], payload[3],
-                     (int)payload_len);
+            uint8_t reason = (payload_len >= 33) ? payload[32] : 0xFF;
+            const char *why = (reason == 0x00) ? "peer disconnected from this relay"
+                            : (reason == 0x01) ? "relay has no path to this peer"
+                            : "unknown reason";
+            ESP_LOGW(TAG, "DERP PeerGone %02x%02x%02x%02x: %s (reason=0x%02x)",
+                     payload[0], payload[1], payload[2], payload[3], why, reason);
+            ml_wg_mgr_notify_derp_gone(ml, payload);
+        }
+        break;
+
+    case DERP_FRAME_HEALTH:
+        /* Server telling us this connection is unhealthy. Its only current use
+         * upstream is duplicate-connection detection (derp.go:118-123) - two
+         * clients on one node key fighting over the same relay session, which
+         * looks exactly like an unreachable node from the outside. Worth
+         * seeing rather than dropping. */
+        if (payload && payload_len > 0) {
+            ESP_LOGW(TAG, "DERP health warning from relay: %.*s",
+                     (int)payload_len, (const char *)payload);
+        } else {
+            ESP_LOGI(TAG, "DERP health warning cleared by relay");
         }
         break;
 

--- a/microlink/components/microlink/src/ml_netcheck.c
+++ b/microlink/components/microlink/src/ml_netcheck.c
@@ -81,6 +81,20 @@ static uint32_t resolve_v4(const char *hostname) {
 /* Rotate derp_rtt_hist and store the netcheck that just completed in slot 0. */
 void ml_netcheck_record_history(microlink_t *ml) {
     if (!ml) return;
+
+    /* Invalidate the history if the DERPMap's region set changed - the slots
+     * are positional, so a reorder would misattribute latencies. */
+    uint32_t sig = 2166136261u;
+    for (int r = 0; r < ml->derp_region_count; r++) {
+        sig = (sig ^ ml->derp_regions[r].region_id) * 16777619u;
+    }
+    if (sig != ml->derp_region_sig) {
+        if (ml->derp_region_sig != 0) {
+            ESP_LOGI(TAG, "DERPMap region set changed - discarding latency history");
+        }
+        memset(ml->derp_rtt_hist, 0, sizeof(ml->derp_rtt_hist));
+        ml->derp_region_sig = sig;
+    }
     for (int h = ML_DERP_RTT_HISTORY - 1; h > 0; h--) {
         memcpy(ml->derp_rtt_hist[h], ml->derp_rtt_hist[h - 1],
                sizeof(ml->derp_rtt_hist[0]));

--- a/microlink/components/microlink/src/ml_netcheck.c
+++ b/microlink/components/microlink/src/ml_netcheck.c
@@ -72,6 +72,51 @@ static uint32_t resolve_v4(const char *hostname) {
     return ip;
 }
 
+/* ---- best-recent latency, per tailscale/net/netcheck/netcheck.go:1525 --------
+ * The reference selects on the lowest latency seen per region across recent
+ * reports, not the newest single probe, so one lossy sample cannot move the
+ * home region. We keep a short ring of past netchecks and take the minimum.
+ * ------------------------------------------------------------------------- */
+
+/* Rotate derp_rtt_hist and store the netcheck that just completed in slot 0. */
+void ml_netcheck_record_history(microlink_t *ml) {
+    if (!ml) return;
+    for (int h = ML_DERP_RTT_HISTORY - 1; h > 0; h--) {
+        memcpy(ml->derp_rtt_hist[h], ml->derp_rtt_hist[h - 1],
+               sizeof(ml->derp_rtt_hist[0]));
+    }
+    memcpy(ml->derp_rtt_hist[0], ml->derp_rtt_ms, sizeof(ml->derp_rtt_hist[0]));
+}
+
+/* Lowest RTT recorded for `region` across the history. 0 = never answered. */
+uint16_t ml_netcheck_best_recent_rtt(const microlink_t *ml, uint16_t region) {
+    if (!ml || region == 0) return 0;
+    int idx = -1;
+    for (int r = 0; r < ml->derp_region_count; r++) {
+        if (ml->derp_regions[r].region_id == region) { idx = r; break; }
+    }
+    if (idx < 0) return 0;
+    uint16_t best = 0;
+    for (int h = 0; h < ML_DERP_RTT_HISTORY; h++) {
+        uint16_t v = ml->derp_rtt_hist[h][idx];
+        if (v > 0 && (best == 0 || v < best)) best = v;
+    }
+    return best;
+}
+
+/* Region with the lowest best-recent RTT. 0 if nothing answered at all. */
+uint16_t ml_netcheck_best_recent_region(const microlink_t *ml) {
+    if (!ml) return 0;
+    uint16_t best_region = 0, best_rtt = 0;
+    for (int r = 0; r < ml->derp_region_count; r++) {
+        uint16_t id = ml->derp_regions[r].region_id;
+        uint16_t v  = ml_netcheck_best_recent_rtt(ml, id);
+        if (v == 0) continue;
+        if (best_rtt == 0 || v < best_rtt) { best_rtt = v; best_region = id; }
+    }
+    return best_region;
+}
+
 uint16_t ml_netcheck_pick_best_derp(microlink_t *ml) {
     if (!ml || ml->derp_region_count == 0) return 0;
 

--- a/microlink/components/microlink/src/ml_wg_mgr.c
+++ b/microlink/components/microlink/src/ml_wg_mgr.c
@@ -1729,7 +1729,11 @@ static void disco_periodic_probes(microlink_t *ml) {
 
         /* Idle-session gate. The reference stops heartbeating a peer whose
          * session has gone quiet (magicsock/endpoint.go:835, sessionActiveTimeout
-         * = 45 s) rather than probing peers it is not talking to. Without this
+         * = 45 s) rather than probing peers it is not talking to. Note one
+         * deliberate deviation: the reference gates on lastSendExt (time since
+         * WE last sent), where this gates on max(last_rx, last_tx). A peer that
+         * keeps sending to us therefore stays probed here - more conservative
+         * than the reference, not equivalent to it. Without this
          * every known peer is probed forever, which on a relay-only device -
          * where every peer costs a full relay round trip - saturates the
          * 32-slot probe table permanently and floods the log. Measured on such

--- a/microlink/components/microlink/src/ml_wg_mgr.c
+++ b/microlink/components/microlink/src/ml_wg_mgr.c
@@ -919,8 +919,24 @@ static void disco_build_ping(microlink_t *ml, int peer_idx,
         }
     }
     if (!registered) {
-        ESP_LOGW(TAG, "DISCO probe table full (%d slots), pong will be unmatched",
-                 MAX_PENDING_PROBES);
+        /* Rate-limited: when the table saturates this fires many times a second,
+         * and on a constrained device the logging itself blocks the main loop
+         * (measured: 3 s stalls, starving the API). One line every 10 s says
+         * the same thing without becoming the fault it is reporting. */
+        {
+            static uint64_t last_full_log_ms = 0;
+            static uint32_t suppressed = 0;
+            uint64_t now_ms = ml_get_time_ms();
+            if (now_ms - last_full_log_ms > 10000) {
+                ESP_LOGW(TAG, "DISCO probe table full (%d slots), pong will be unmatched"
+                              " (%lu more suppressed in the last 10s)",
+                         MAX_PENDING_PROBES, (unsigned long)suppressed);
+                last_full_log_ms = now_ms;
+                suppressed = 0;
+            } else {
+                suppressed++;
+            }
+        }
     }
 }
 
@@ -1694,6 +1710,34 @@ static void disco_periodic_probes(microlink_t *ml) {
         bool peer_allowed = ml_config_peer_is_allowed(
             ml->config_httpd, p->vpn_ip);
 
+        /* Idle-session gate. The reference stops heartbeating a peer whose
+         * session has gone quiet (magicsock/endpoint.go:835, sessionActiveTimeout
+         * = 45 s) rather than probing peers it is not talking to. Without this
+         * every known peer is probed forever, which on a relay-only device -
+         * where every peer costs a full relay round trip - saturates the
+         * 32-slot probe table permanently and floods the log. Measured on such
+         * a board: active_probes pinned at 32/32 with 4 peers, and the logging
+         * alone blocking the main loop for 3 s at a time.
+         *
+         * Trust expiry below still runs: this gates new probes, not bookkeeping. */
+        bool session_idle = false;
+        if (p->wg_peer_index >= 0 && p->wg_peer_index < WIREGUARD_MAX_PEERS && ml->wg_netif) {
+            struct netif *netif_i = (struct netif *)ml->wg_netif;
+            struct wireguard_device *dev_i = (struct wireguard_device *)netif_i->state;
+            if (dev_i) {
+                struct wireguard_peer *wp_i = &dev_i->peers[p->wg_peer_index];
+                uint32_t now_wg = wireguard_sys_now();
+                uint32_t last_any = wp_i->last_rx;
+                if (wp_i->last_tx > last_any) last_any = wp_i->last_tx;
+                if (last_any != 0) {
+                    uint32_t age = now_wg - last_any;
+                    if (age <= 0x7FFFFFFFu && age > ML_DISCO_SESSION_ACTIVE_MS) {
+                        session_idle = true;
+                    }
+                }
+            }
+        }
+
         /* Check if direct path trust has expired (always runs, not throttled).
          *
          * Throughput-collapse fix (2026-05-24): the old code unconditionally
@@ -1830,7 +1874,7 @@ static void disco_periodic_probes(microlink_t *ml) {
         /* Probe for direct path upgrade (every UPGRADE_INTERVAL when on DERP).
          * Skip on cellular: direct paths impossible through carrier-grade NAT.
          * Throttled to DISCO_PROBES_PER_TICK to spread load and reduce jitter. */
-        if (!ml_at_socket_is_ready() && !p->has_direct_path &&
+        if (!session_idle && !ml_at_socket_is_ready() && !p->has_direct_path &&
             now - p->last_upgrade_ms > ML_DISCO_UPGRADE_INTERVAL_MS) {
             if (upgrade_probes_sent < DISCO_PROBES_PER_TICK) {
                 disco_send_ping_to_peer(ml, i, false);
@@ -1843,7 +1887,7 @@ static void disco_periodic_probes(microlink_t *ml) {
          * MUST use force=true because HEARTBEAT_MS (3s) < PING_INTERVAL_MS (5s),
          * so the rate limiter would always block heartbeat pings.
          * Heartbeats are NEVER throttled — they're time-critical for trust_until_ms. */
-        if (p->has_direct_path &&
+        if (!session_idle && p->has_direct_path &&
             now - p->last_ping_sent_ms > ml->t_disco_heartbeat_ms) {
             disco_send_ping_to_peer(ml, i, true);
         }

--- a/microlink/components/microlink/src/ml_wg_mgr.c
+++ b/microlink/components/microlink/src/ml_wg_mgr.c
@@ -783,6 +783,23 @@ static int add_peer(microlink_t *ml, const ml_peer_update_t *update) {
     return idx;
 }
 
+/* Called from the DERP task when a relay reports PeerGone. The reference drops
+ * its DERP route for the peer (magicsock/derp.go:652-665); there is no route
+ * table here, so the equivalent is to stop pushing WireGuard handshakes through
+ * a relay that has just said it cannot deliver them. Writing one timestamp from
+ * another task is safe: a torn read costs at most one extra or skipped retry. */
+void ml_wg_mgr_notify_derp_gone(microlink_t *ml, const uint8_t *public_key) {
+    if (!ml || !public_key) return;
+    for (int i = 0; i < ml->peer_count; i++) {
+        if (!ml->peers[i].active) continue;
+        if (memcmp(ml->peers[i].public_key, public_key, 32) != 0) continue;
+        ml->peers[i].derp_gone_until_ms = ml_get_time_ms() + ML_DERP_GONE_BACKOFF_MS;
+        ESP_LOGW(TAG, "Relay reports no path to %s - pausing DERP handshakes for %ds",
+                 ml->peers[i].hostname, ML_DERP_GONE_BACKOFF_MS / 1000);
+        return;
+    }
+}
+
 static void remove_peer(microlink_t *ml, const ml_peer_update_t *update) {
     int idx = find_peer_by_key(ml, update->public_key);
     if (idx < 0) return;

--- a/microlink/components/microlink/src/ml_wg_mgr.c
+++ b/microlink/components/microlink/src/ml_wg_mgr.c
@@ -1151,6 +1151,10 @@ static void process_disco_pong(microlink_t *ml, const ml_rx_packet_t *pkt,
              * we'll switch back to direct (handled by wireguardif_update_endpoint
              * a few lines below with the new pkt->src_ip:src_port). */
             p->derp_fallback_active = false;
+            /* We have heard from this peer, so whatever a relay told us earlier
+             * is stale - resume normal behaviour immediately rather than
+             * waiting out the PeerGone backoff. */
+            p->derp_gone_until_ms = 0;
 
             /* Update WireGuard endpoint to direct path.
              * Always update the stored endpoint. Only force a handshake if we
@@ -1806,6 +1810,12 @@ static void disco_periodic_probes(microlink_t *ml) {
             bool first_attempt = !p->derp_fallback_active;
             bool attempt_due = (p->last_derp_attempt_ms == 0) ||
                                (now - p->last_derp_attempt_ms > 30000);
+            /* A relay that has reported PeerGone for this peer cannot deliver
+             * to it; retrying every 30 s achieves nothing but load on the relay
+             * and the device. */
+            if (p->derp_gone_until_ms != 0 && now < p->derp_gone_until_ms) {
+                attempt_due = false;
+            }
             if (up != ERR_OK && attempt_due) {
                 wireguardif_connect_derp(netif, (u8_t)p->wg_peer_index);
                 p->derp_fallback_active = true;

--- a/microlink/components/microlink/src/ml_wg_mgr.c
+++ b/microlink/components/microlink/src/ml_wg_mgr.c
@@ -707,6 +707,7 @@ static int add_peer(microlink_t *ml, const ml_peer_update_t *update) {
     p->last_pong_recv_ms = 0;
     p->trust_until_ms = 0;
     p->last_send_ms = 0;
+    p->last_data_recv_ms = 0;
     p->last_upgrade_ms = 0;
     p->has_direct_path = false;
     p->best_ip = 0;
@@ -783,20 +784,43 @@ static int add_peer(microlink_t *ml, const ml_peer_update_t *update) {
     return idx;
 }
 
-/* Called from the DERP task when a relay reports PeerGone. The reference drops
- * its DERP route for the peer (magicsock/derp.go:652-665); there is no route
- * table here, so the equivalent is to stop pushing WireGuard handshakes through
- * a relay that has just said it cannot deliver them. Writing one timestamp from
- * another task is safe: a torn read costs at most one extra or skipped retry. */
+/* Called from the DERP RX task when a relay reports PeerGone. The reference
+ * drops its DERP route for the peer (magicsock/derp.go:652-665); here the
+ * equivalent is to stop pushing WireGuard handshakes through a relay that just
+ * said it cannot deliver them. A PeerGone burst is NORMAL on a relay whose
+ * peers live elsewhere, so this DERP-task path stays cheap and does not own
+ * ml->peers: it hands the 32-byte key to wg_mgr via a dedicated queue. wg_mgr
+ * (sole owner of ml->peers) applies the backoff and logs, rate-limited, in
+ * drain_derp_gone_queue(). Drop if the queue is full - the backoff is advisory
+ * and the next PeerGone for the same peer re-arms it. */
 void ml_wg_mgr_notify_derp_gone(microlink_t *ml, const uint8_t *public_key) {
-    if (!ml || !public_key) return;
-    for (int i = 0; i < ml->peer_count; i++) {
-        if (!ml->peers[i].active) continue;
-        if (memcmp(ml->peers[i].public_key, public_key, 32) != 0) continue;
-        ml->peers[i].derp_gone_until_ms = ml_get_time_ms() + ML_DERP_GONE_BACKOFF_MS;
-        ESP_LOGW(TAG, "Relay reports no path to %s - pausing DERP handshakes for %ds",
-                 ml->peers[i].hostname, ML_DERP_GONE_BACKOFF_MS / 1000);
-        return;
+    if (!ml || !public_key || !ml->derp_gone_queue) return;
+    (void)xQueueSend(ml->derp_gone_queue, public_key, 0);
+}
+
+/* Drained on the wg_mgr task (sole owner of ml->peers). Applies the DERP
+ * backoff each queued PeerGone asked for, rate-limiting the log so a burst
+ * cannot become the stall it reports (cf. the DISCO probe-table-full log). */
+static void drain_derp_gone_queue(microlink_t *ml) {
+    if (!ml->derp_gone_queue) return;
+    uint8_t key[32];
+    while (xQueueReceive(ml->derp_gone_queue, key, 0) == pdTRUE) {
+        int idx = find_peer_by_key(ml, key);
+        if (idx < 0 || !ml->peers[idx].active) continue;
+        ml->peers[idx].derp_gone_until_ms = ml_get_time_ms() + ML_DERP_GONE_BACKOFF_MS;
+        static uint64_t last_log_ms = 0;
+        static uint32_t suppressed = 0;
+        uint64_t now_ms = ml_get_time_ms();
+        if (now_ms - last_log_ms > 10000) {
+            ESP_LOGW(TAG, "Relay reports no path to %s - pausing DERP handshakes for %ds"
+                          " (%lu more suppressed in the last 10s)",
+                     ml->peers[idx].hostname, ML_DERP_GONE_BACKOFF_MS / 1000,
+                     (unsigned long)suppressed);
+            last_log_ms = now_ms;
+            suppressed = 0;
+        } else {
+            suppressed++;
+        }
     }
 }
 
@@ -1467,6 +1491,12 @@ static void process_wg_packet(microlink_t *ml, const ml_rx_packet_t *pkt) {
         free(pkt->data);
         return;
     }
+    /* wg_mgr's own inbound-activity stamp for this peer, so the DISCO idle-gate
+     * reads wg_mgr state instead of struct wireguard_peer from the probe loop. */
+    {
+        int pidx = find_peer_by_key(ml, pkt->src_pubkey);
+        if (pidx >= 0) ml->peers[pidx].last_data_recv_ms = ml_get_time_ms();
+    }
 
     struct netif *netif = (struct netif *)ml->wg_netif;
     void *device = netif->state;
@@ -1741,21 +1771,22 @@ static void disco_periodic_probes(microlink_t *ml) {
          * alone blocking the main loop for 3 s at a time.
          *
          * Trust expiry below still runs: this gates new probes, not bookkeeping. */
+        /* Idleness from wg_mgr's OWN bookkeeping - last inbound WG data
+         * (stamped in process_wg_packet) or last DISCO pong - never a
+         * cross-task read of struct wireguard_peer from this probe loop. Both
+         * are ml_get_time_ms() timestamps; 0 == "never heard from", so at boot
+         * nothing is idle (the gate is blind then - the rate-limited
+         * probe-table-full log is what protects against the boot probe storm).
+         * Deviation from the reference (endpoint.go:835 gates on lastSend): we
+         * gate on last-HEARD, because wg_mgr does not see the data-tx path and
+         * stamping our own DISCO sends here would make the gate self-sustaining
+         * (a peer we keep probing would never look idle). */
         bool session_idle = false;
-        if (p->wg_peer_index >= 0 && p->wg_peer_index < WIREGUARD_MAX_PEERS && ml->wg_netif) {
-            struct netif *netif_i = (struct netif *)ml->wg_netif;
-            struct wireguard_device *dev_i = (struct wireguard_device *)netif_i->state;
-            if (dev_i) {
-                struct wireguard_peer *wp_i = &dev_i->peers[p->wg_peer_index];
-                uint32_t now_wg = wireguard_sys_now();
-                uint32_t last_any = wp_i->last_rx;
-                if (wp_i->last_tx > last_any) last_any = wp_i->last_tx;
-                if (last_any != 0) {
-                    uint32_t age = now_wg - last_any;
-                    if (age <= 0x7FFFFFFFu && age > ML_DISCO_SESSION_ACTIVE_MS) {
-                        session_idle = true;
-                    }
-                }
+        {
+            uint64_t last_heard = p->last_data_recv_ms;
+            if (p->last_pong_recv_ms > last_heard) last_heard = p->last_pong_recv_ms;
+            if (last_heard != 0 && (ml_get_time_ms() - last_heard) > ML_DISCO_SESSION_ACTIVE_MS) {
+                session_idle = true;
             }
         }
 
@@ -2085,6 +2116,7 @@ void ml_wg_mgr_task(void *arg) {
     while (!(xEventGroupGetBits(ml->events) & ML_EVT_SHUTDOWN_REQUEST)) {
         /* Process peer updates from coord task */
         process_peer_updates(ml);
+        drain_derp_gone_queue(ml);
 
         /* Track DERP connection state for DISCO.
          * Note: We DON'T re-initiate WG handshakes on DERP connect because


### PR DESCRIPTION
Rebased onto v0.5.5. This is findings #1 and #2 combined, as you asked in #33.

## #1 — the home DERP region is chosen by a loop that echoes itself

`NetInfo.PreferredDERP` was populated from `derp_region_default`, which is a value that came **from** the control plane — and the control plane echoes back whatever the client sends. So the first region is self-sustaining:

```
control echoes X  ->  we adopt X  ->  we send X  ->  control echoes X ...
```

`ML_DERP_REGION 4` (Frankfurt) is a compile-time constant and the only fallback, so a device that never breaks the loop stays on Frankfurt permanently, everywhere in the world.

Netcheck measures every region correctly the whole time. The measurements simply had no path to the decision — the override plumbing exists in the C but nothing exposed a way to reach it, and `config.preferred_derp_region` was always 0.

Observed here: two ESP32-S3 boards in Australia sat on `fra` at **682-927 ms** while Sydney answered in **~10 ms**, surviving reboots. The practical cost was an OTA taking **498 s** that takes **25.8 s** on the correct region.

**This PR reports our own netcheck choice** and selects on best-recent latency across several netchecks rather than a single probe. Movement requires **both** an absolute margin (>=10 ms) and a proportional one (<=2/3 of the incumbent), so near-equal regions do not ping-pong — modelled on `net/netcheck/netcheck.go:1427-1500` and `wgengine/magicsock/derp.go:197`.

Verified on hardware: `Home DERP changing 4 (254ms) -> 5 (52ms)`, one change then stable.

Related fixes in the series, each its own commit:
- A lost STUN probe is not proof the home region is down.
- Discard latency history when the DERPMap region set changes — stale RTTs for regions that no longer exist.
- Never move an established home DERP without a live control connection.
- Don't let the server echo overwrite a region we have chosen.
- Home-DERP changes now log at WARN; they are rare and consequential.

## #2 — announce the change before moving to it

The ordering matters and is easy to get backwards: if the device moves to the new home region and *then* tells the control plane, there is a window where peers are still being told to reach it at the old region while it is no longer listening there. Announce first, then move.

I have put that reasoning in a comment at the site rather than only in the commit message, since it is exactly the kind of thing that gets "simplified" back out by someone reading the code alone.

## Please note — this branch also carries finding #6

The idle-peer probe gating (#6) is entangled with the DERP work in this series: it shares `ml_wg_mgr.c` changes with the DERP `PeerGone` handling and the probe-table saturation logging. I have left it in rather than attempt a split that I could not build-test cleanly. **Happy to separate it if you would rather review it on its own** — say the word and I will rebase it out.

## Also included

`netcheck_override` is honoured again (it had been left unreachable), and a duplicate define is dropped.

## Testing

Two ESP32-S3 boards, ~85-node Tailscale SaaS tailnet, Australia — which is what made the Frankfurt pinning so visible. The offer stands to field-test against the symmetric-NAT site for this one specifically, since you mentioned your bench can't produce honest cross-continent latency.