### PR TITLE
fix: check the RegisterResponse fields that actually indicate failure

### DIFF
--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -1501,40 +1501,90 @@ static int do_register(microlink_t *ml, ml_noise_state_t *noise) {
     parse_start[parse_len] = saved;
     free(resp_buf);
 
-    /* Sanity-check the User block before anything else. Headscale will
-     * still 200 the Register call when the auth_key is bogus or the
-     * node-key was previously registered but the server-side record is
-     * gone — only the JSON betrays the truth (User.ID=0, empty
-     * DisplayName). Without surfacing it here, the first user-visible
-     * symptom is a "node not found" from the next MapRequest, which
-     * reads like a generic transport problem. */
+    /* Check the RegisterResponse status fields the reference client acts on.
+     *
+     * The status fields the reference ACTS ON (direct.go:883-931) are:
+     *
+     *   resp.Error          -> fatal; "if non-empty, other status fields
+     *                          should be ignored" (tailcfg.go:1359)
+     *   resp.NodeKeyExpired -> node key must be replaced
+     *   resp.AuthURL        -> authorization pending, not yet usable
+     *   resp.User.ID        -> DISPLAY ONLY, copied into persist.UserProfile
+     *
+     * (It also handles resp.NodeKeySignature for tailnet lock, which microlink
+     * does not implement, and logs resp.MachineAuthorized.)
+     *
+     * This previously errored on `User.ID == 0 && User.DisplayName == ""`,
+     * which is not a health signal in either half:
+     *
+     *   - User.DisplayName is documented as an OVERRIDE - "if non-empty
+     *     overrides Login field" (tailcfg.go:271). Empty is the normal case;
+     *     the reference reads the real name from resp.Login.DisplayName.
+     *   - A node with no bound user is legitimate. Auth-key registrations,
+     *     and tag-owned nodes in particular, are owned by a tag rather than
+     *     a user, so User.ID == 0 is expected rather than exceptional.
+     *
+     * Observed on a healthy ESP32-S3: a tag-owned node registered by auth key
+     * logged this as ESP_LOGE on every boot while holding a valid address,
+     * exchanging map updates and passing traffic. */
     {
-        cJSON *user = cJSON_GetObjectItem(resp_json, "User");
-        int   id_val   = -1;
+        cJSON *err_j = cJSON_GetObjectItem(resp_json, "Error");
+        if (err_j && cJSON_IsString(err_j) && err_j->valuestring && *err_j->valuestring) {
+            ESP_LOGE(TAG, "RegisterResponse.Error: %s", err_j->valuestring);
+            ESP_LOGE(TAG, "  Registration was refused by the control plane. "
+                          "Check the auth_key is valid and not expired.");
+            cJSON_Delete(resp_json);
+            return -1;
+        }
+
+        cJSON *exp_j = cJSON_GetObjectItem(resp_json, "NodeKeyExpired");
+        if (exp_j && cJSON_IsTrue(exp_j)) {
+            /* The reference regenerates the node key and re-registers
+             * automatically here (direct.go:890-897 returns regen=true). We do
+             * not implement automatic regeneration, so this is fatal and needs
+             * operator action - a microlink divergence, not reference behaviour. */
+            ESP_LOGE(TAG, "RegisterResponse.NodeKeyExpired - this node key is no "
+                          "longer accepted. microlink does not regenerate keys "
+                          "automatically: run microlink_factory_reset + reboot.");
+            cJSON_Delete(resp_json);
+            return -1;
+        }
+
+        cJSON *url_j = cJSON_GetObjectItem(resp_json, "AuthURL");
+        if (url_j && cJSON_IsString(url_j) && url_j->valuestring && *url_j->valuestring) {
+            ESP_LOGW(TAG, "RegisterResponse.AuthURL set - authorization is pending. "
+                          "Approve this node at: %s", url_j->valuestring);
+        }
+
+        /* Identity, for logging only. ID from User, name from Login (with the
+         * User.DisplayName override applied if present) - as the reference does. */
+        cJSON *user  = cJSON_GetObjectItem(resp_json, "User");
+        cJSON *login = cJSON_GetObjectItem(resp_json, "Login");
+        int id_val = 0;
         const char *name_val = "";
         if (user) {
-            cJSON *id_j   = cJSON_GetObjectItem(user, "ID");
-            cJSON *name_j = cJSON_GetObjectItem(user, "DisplayName");
-            if (id_j   && cJSON_IsNumber(id_j))   id_val   = id_j->valueint;
-            if (name_j && cJSON_IsString(name_j)) name_val = name_j->valuestring;
+            cJSON *id_j = cJSON_GetObjectItem(user, "ID");
+            if (id_j && cJSON_IsNumber(id_j)) id_val = id_j->valueint;
+        }
+        if (login) {
+            cJSON *n = cJSON_GetObjectItem(login, "DisplayName");
+            if (!n || !cJSON_IsString(n) || !n->valuestring || !*n->valuestring)
+                n = cJSON_GetObjectItem(login, "LoginName");
+            if (n && cJSON_IsString(n) && n->valuestring) name_val = n->valuestring;
+        }
+        if (user) {   /* User.DisplayName overrides Login when non-empty */
+            cJSON *dn = cJSON_GetObjectItem(user, "DisplayName");
+            if (dn && cJSON_IsString(dn) && dn->valuestring && *dn->valuestring)
+                name_val = dn->valuestring;
         }
         ml->register_user_id = id_val;
-        strlcpy(ml->register_user_name, name_val ? name_val : "",
-                sizeof ml->register_user_name);
-        if (id_val == 0 && (!name_val || !*name_val)) {
-            ESP_LOGE(TAG,
-                "RegisterResponse User.ID=0 + DisplayName=\"\" — the "
-                "control plane accepted the connect but didn't bind us "
-                "to a real user.");
-            ESP_LOGE(TAG,
-                "  Most likely: the auth_key is invalid/expired, or the "
-                "node-key was previously registered and then deleted on "
-                "the server. Fix: regenerate the device identity "
-                "(microlink_factory_reset + reboot) or supply a fresh "
-                "auth_key + reauthorize the node on the control plane.");
-        } else if (id_val > 0) {
-            ESP_LOGI(TAG, "Registered as User.ID=%d \"%s\"",
-                     id_val, name_val ? name_val : "");
+        strlcpy(ml->register_user_name, name_val, sizeof ml->register_user_name);
+
+        if (id_val > 0 || *name_val) {
+            ESP_LOGI(TAG, "Registered as User.ID=%d \"%s\"", id_val, name_val);
+        } else {
+            /* Normal for auth-key and tag-owned registrations. */
+            ESP_LOGI(TAG, "Registered (no bound user - auth-key or tag-owned node)");
         }
     }
 


### PR DESCRIPTION
Rebased onto current `main`. This is finding #4 from #33 — small and self-contained, as you suggested.

## The symptom

My tag-owned boards log this on every boot, in red, telling me to factory reset them — while they are perfectly healthy, holding an address, exchanging map updates and passing traffic:

```
RegisterResponse User.ID=0 + DisplayName="" - the control plane accepted the
connect but didn't bind us to a real user.
```

## Why I think the check reads the wrong fields

Both halves of it look like normal values to me:

- `User.DisplayName` is documented as an override — *"if non-empty overrides Login field"* (`tailcfg.go:271`) — so empty is the usual case. The Go client takes the display name from `Login.DisplayName`, not `User`.
- **A node with no bound user is legitimate.** Auth-key registrations, and tag-owned nodes especially, belong to a tag rather than a user, so `User.ID == 0` is expected. The response really does begin `{"User":{"ID":0,"DisplayName":""…`.

## And the fields the Go client acts on were not being read

`control/controlclient/direct.go:883-931`:

```go
if resp.Error != "" { ... }        // fatal; other fields to be ignored
if resp.NodeKeyExpired { ... }     // key must be replaced
if resp.AuthURL != "" { ... }      // authorization pending
persist.UserProfile = ...resp.User.ID...   // display only
```

So a genuinely refused registration — an expired auth key, which sets `Error` — said nothing here, and surfaced later as an opaque "node not found" from the next MapRequest. That confusing failure is what the original check was clearly trying to prevent, which is what makes me fairly confident this is a wrong-field slip rather than intentional.

## After this PR

`Error` and `NodeKeyExpired` are fatal with a specific message, `AuthURL` warns with the approval URL, and the identity is logged for information only — including the no-bound-user case, stated as normal.

**One deliberate divergence worth flagging:** the Go client regenerates the node key and re-registers automatically on `NodeKeyExpired` (`direct.go:890-897`). We have no automatic regeneration, so I have left that path reporting that it needs operator action rather than implying the reference behaviour.

## Testing

Builds clean against current main on ESP32-S3 (ESPHome 2026.6.5, ESP-IDF). Running on two boards on an ~85-node Tailscale SaaS tailnet, both tag-owned — which is why the false alarm was so visible here.