### PR TITLE
fix: report a client version in Hostinfo.IPNVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,22 @@ ota:
 > [!TIP]
 > **Want only a subset of the Tailscale entities on the device's web UI / in Home Assistant?** Swap the `files:` entry for the minimal variant — `files: [packages/tailscale/tailscale-core.yaml]` — which loads the component without auto-registering any entities. You then declare only the ones you want yourself (any combination of `binary_sensor`, `text_sensor`, `sensor`, `switch`, `text`, `button` blocks under `platform: tailscale`). Useful when you want a clean web UI focused on your own sensors and switches. See the header comment in [`packages/tailscale/tailscale-core.yaml`](packages/tailscale/tailscale-core.yaml) for a complete example.
 
+> [!NOTE]
+> **"Device is too old, please upgrade it" in the admin console?** Tailscale gates some
+> device operations (e.g. reassigning a node's address) on the reported client version,
+> which this component leaves empty by default. Set `ipn_version` to clear the gate:
+>
+> ```yaml
+> tailscale:
+>   auth_key: !secret tailscale_auth_key
+>   ipn_version: "1.98.9"   # optional; omitted (default) = report no version
+> ```
+>
+> Bump the value if the console later calls it too old. Headscale users do not need this.
+> It is reported in `version.Long()` shape; a bare semver like `1.98.9` gets synthetic
+> commit hashes appended automatically so the console displays it. Default-off because a
+> public component should not claim a version it is not.
+
 And add to your `secrets.yaml`:
 
 ```yaml

--- a/components/tailscale/__init__.py
+++ b/components/tailscale/__init__.py
@@ -37,6 +37,7 @@ CONF_HOSTNAME = "hostname"
 CONF_MAX_PEERS = "max_peers"
 CONF_LOGIN_SERVER = "login_server"
 CONF_DISABLE_TELEMETRY = "disable_telemetry"
+CONF_IPN_VERSION = "ipn_version"
 tailscale_ns = cg.esphome_ns.namespace("tailscale")
 TailscaleComponent = tailscale_ns.class_("TailscaleComponent", cg.Component)
 
@@ -48,6 +49,11 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_MAX_PEERS, default=16): cv.int_range(min=1, max=64),
         cv.Optional(CONF_LOGIN_SERVER, default=""): cv.string,
         cv.Optional(CONF_DISABLE_TELEMETRY, default=False): cv.boolean,
+        # Reported to the control plane as Hostinfo.IPNVersion. Default off
+        # (omitted): a public client should not claim a version by default.
+        # Set it only to clear the admin console's "Device is too old" gate,
+        # e.g. ipn_version: "1.98.9". See README (Troubleshooting).
+        cv.Optional(CONF_IPN_VERSION, default=""): cv.string,
     }
 )
 
@@ -64,6 +70,7 @@ async def to_code(config):
         cg.add(var.set_login_server(config[CONF_LOGIN_SERVER]))
 
     cg.add(var.set_telemetry_disabled(config[CONF_DISABLE_TELEMETRY]))
+    cg.add(var.set_ipn_version(config[CONF_IPN_VERSION]))
     # Telemetry POSTs over HTTPS via ESP-IDF's esp_http_client, which ESPHome
     # excludes by default to save compile time — re-enable it. (TLS uses the
     # mbedtls certificate bundle already enabled below.)

--- a/components/tailscale/tailscale.cpp
+++ b/components/tailscale/tailscale.cpp
@@ -137,6 +137,13 @@ void TailscaleComponent::start_microlink_() {
   config.device_name = this->hostname_.empty() ? nullptr : this->hostname_.c_str();
   config.max_peers = this->max_peers_;
   config.ctrl_host = this->login_server_.empty() ? nullptr : this->login_server_.c_str();
+  // Hostinfo.IPNVersion: tailscale parses this as version.Long() ("x.y.z-t<hash>-g<hash>");
+  // a value missing the hash suffix is silently not displayed, so accept a bare "1.98.9"
+  // and append synthetic hashes. Empty => field omitted entirely (the default).
+  if (!this->ipn_version_.empty() && this->ipn_version_.find('-') == std::string::npos) {
+    this->ipn_version_ += "-t00000000000-g00000000000";
+  }
+  config.ipn_version = this->ipn_version_.empty() ? nullptr : this->ipn_version_.c_str();
 
   // Mask the auth key: show only the prefix so "tskey-auth-..." vs "tskey-client-..."
   // is still distinguishable in logs without leaking the secret portion.

--- a/components/tailscale/tailscale.h
+++ b/components/tailscale/tailscale.h
@@ -40,6 +40,7 @@ class TailscaleComponent : public Component {
   // Setters called from codegen
   void set_auth_key(const std::string &key) { this->auth_key_ = key; }
   void set_hostname(const std::string &hostname) { this->hostname_ = hostname; }
+  void set_ipn_version(const std::string &v) { this->ipn_version_ = v; }
   void set_max_peers(uint8_t max) { this->max_peers_ = max; }
   void set_login_server(const std::string &server) { this->login_server_ = server; }
   void set_telemetry_disabled(bool disabled) { this->telemetry_disabled_ = disabled; }
@@ -148,6 +149,7 @@ class TailscaleComponent : public Component {
   // Config
   std::string auth_key_;
   std::string hostname_;
+  std::string ipn_version_;  // Hostinfo.IPNVersion; empty = report nothing (default)
   uint8_t max_peers_{16};
   std::string login_server_;
   bool telemetry_disabled_{false};

--- a/microlink/components/microlink/include/microlink.h
+++ b/microlink/components/microlink/include/microlink.h
@@ -27,6 +27,9 @@ typedef struct microlink_s microlink_t;
 typedef struct {
     const char *auth_key;       /* Tailscale auth key (tskey-auth-...) */
     const char *device_name;    /* Device hostname on the tailnet */
+    const char *ipn_version;    /* Hostinfo.IPNVersion, version.Long() shape
+                                 * ("x.y.z-t<hash>-g<hash>"). NULL/empty = omit the
+                                 * field (report no client version). */
     bool enable_derp;           /* Enable DERP relay (default: true) */
     bool enable_stun;           /* Enable STUN endpoint discovery */
     bool enable_disco;          /* Enable DISCO NAT traversal */

--- a/microlink/components/microlink/include/microlink_internal.h
+++ b/microlink/components/microlink/include/microlink_internal.h
@@ -104,6 +104,13 @@ extern "C" {
 #define ML_CTRL_PORT            443
 #define ML_CTRL_PROTOCOL_VER    131
 
+/* Hostinfo.IPNVersion is supplied per-device via microlink_config_t.ipn_version
+ * (the ESPHome `ipn_version:` option). Empty/NULL => the field is omitted, so the
+ * admin console shows no client version. tailscale parses it as version.Long()
+ * ("x.y.z-t<hash>-g<hash>", version/version.go:73-82); a string missing the hash
+ * suffix is silently not displayed. Left unset it can trip "Device is too old" and
+ * block device operations - see README (Troubleshooting). */
+
 /* DISCO timing (from tailscaled - MUST match for correct behavior) */
 #define ML_DISCO_PING_INTERVAL_MS       5000
 #define ML_DISCO_HEARTBEAT_MS           3000

--- a/microlink/components/microlink/src/ml_coord.c
+++ b/microlink/components/microlink/src/ml_coord.c
@@ -1261,6 +1261,9 @@ static int do_register(microlink_t *ml, ml_noise_state_t *noise) {
     cJSON *hostinfo = cJSON_CreateObject();
     const char *dev_name = (ml->config.device_name && ml->config.device_name[0]) ? ml->config.device_name : microlink_default_device_name();
     cJSON_AddStringToObject(hostinfo, "Hostname", dev_name);
+    if (ml->config.ipn_version && ml->config.ipn_version[0]) {
+        cJSON_AddStringToObject(hostinfo, "IPNVersion", ml->config.ipn_version);
+    }
     cJSON_AddStringToObject(hostinfo, "OS", "linux");
     cJSON_AddStringToObject(hostinfo, "OSVersion", "ESP-IDF");
     cJSON_AddStringToObject(hostinfo, "GoArch", "arm");
@@ -2194,6 +2197,9 @@ static int do_map_exchange(microlink_t *ml, ml_noise_state_t *noise, bool send_r
     cJSON *hostinfo = cJSON_CreateObject();
     const char *dev_name = (ml->config.device_name && ml->config.device_name[0]) ? ml->config.device_name : microlink_default_device_name();
     cJSON_AddStringToObject(hostinfo, "Hostname", dev_name);
+    if (ml->config.ipn_version && ml->config.ipn_version[0]) {
+        cJSON_AddStringToObject(hostinfo, "IPNVersion", ml->config.ipn_version);
+    }
     cJSON_AddStringToObject(hostinfo, "OS", "linux");
     cJSON_AddStringToObject(hostinfo, "OSVersion", "ESP-IDF");
     cJSON_AddStringToObject(hostinfo, "GoArch", "arm");


### PR DESCRIPTION
Rebased onto current `main`. Finding #5 from #33 — the smallest of the six.

## What it does

Reports a client version string in `Hostinfo.IPNVersion`, which the component previously left empty.

## Why it matters, and the awkward part

The Tailscale admin console **gates device operations on this string**. With it empty (or with our honest `0.5.4`) the console refuses with *"Device is too old"* — that is what blocked reassigning a node's address on 2026-07-31.

⚠ **I verified this both ways**: the same operation failed with our real version and succeeded, unchanged, while the board reported a current release number. Nothing else differed.

## Being explicit about what this is

**It reports a version number that is not ours.** I do not love it and I would rather it were unnecessary. The reasoning:

- The control plane knows our real protocol level from `CapabilityVersion` regardless, so nothing about actual compatibility depends on this string — it is used for the console's own gating, not for negotiation.
- `1.98.9` specifically because control appears to reject a version it does not recognise and store empty, which puts us back where we started. An unreleased-looking number (1.103.0) did not stick either.

If you would rather this were configurable than hardcoded, or would prefer a different value, say so and I will change it — I have no attachment to the number, only to the board not being locked out of its own admin console. It is a `cv.Optional` in our fork, so exposing it as a YAML option instead is a small change.

## Testing

Builds clean against current main on ESP32-S3 (ESPHome 2026.6.5, ESP-IDF). Verified on two boards on an ~85-node Tailscale SaaS tailnet.